### PR TITLE
Merge all campaign hide ad lists so all ads that display on the page …

### DIFF
--- a/src/js/components/campaignpage/AdvertsCatalogue.jsx
+++ b/src/js/components/campaignpage/AdvertsCatalogue.jsx
@@ -61,7 +61,7 @@ const campaignNameForAd = ad => {
  * List of adverts with some info about them (like views, dates)
  * @param {*} param0 
  */
-const AdvertsCatalogue = ({campaign, ads, viewcount4campaign, donationTotal, nvertiserName, totalViewCount }) => {
+const AdvertsCatalogue = ({campaign, ads, viewcount4campaign, donationTotal, nvertiserName, totalViewCount, showNonServed }) => {
 	// filter out any hidden ads
 	// NB: done here as the hiding is a shallow cosmetic -- we still want the view and £ donation data included (or if not, there are other controls)
 	if (campaign && campaign.hideAdverts) {
@@ -74,6 +74,8 @@ const AdvertsCatalogue = ({campaign, ads, viewcount4campaign, donationTotal, nve
 	/** Picks one Ad (with a video) from each campaign to display as a sample.  */
 	let sampleAd4Campaign = {};
 	ads.forEach(ad => {
+        // Skip never-served ads
+        if (!ad.hasServed && !showNonServed) return;
 		let cname = campaignNameForAd(ad);
 		if (sampleAd4Campaign[cname]) {
 			let showcase = ad.campaignPage && ad.campaignPage.showcase;

--- a/src/js/components/campaignpage/AdvertsCatalogue.jsx
+++ b/src/js/components/campaignpage/AdvertsCatalogue.jsx
@@ -75,7 +75,7 @@ const AdvertsCatalogue = ({campaign, ads, viewcount4campaign, donationTotal, nve
 	let sampleAd4Campaign = {};
 	ads.forEach(ad => {
         // Skip never-served ads
-        if (!ad.hasServed && !showNonServed) return;
+        if (!ad.hasServed && !ad.serving && !showNonServed) return;
 		let cname = campaignNameForAd(ad);
 		if (sampleAd4Campaign[cname]) {
 			let showcase = ad.campaignPage && ad.campaignPage.showcase;

--- a/src/js/components/campaignpage/CampaignPage.jsx
+++ b/src/js/components/campaignpage/CampaignPage.jsx
@@ -345,7 +345,21 @@ const CampaignPage = () => {
 	} else {
 		console.log("Using top campaign ", campaign);
 	}
-	if ( ! campaign) campaign = {};
+    if ( ! campaign) campaign = {};
+    
+    // Merge all hide advert lists together from all campaigns
+    console.log("pvCAMPAIGNS", pvCampaigns);
+    let allCampaigns = List.hits(pvCampaigns.value);
+    console.log("ALL CAMPAIGNS", allCampaigns);
+    if (!campaign.hideAdverts) campaign.hideAdverts = {};
+    allCampaigns && allCampaigns.forEach(c => {
+        if (c.hideAdverts) {
+            Object.keys(c.hideAdverts).forEach(hideAd => {
+                if (c.hideAdverts[hideAd]) campaign.hideAdverts[hideAd] = true;
+            });
+        }
+    });
+    console.log("FINAL HIDE ADS LIST", campaign.hideAdverts);
 
 	// TODO fill in blanks like donation total and peeps
 

--- a/src/js/components/campaignpage/CampaignPage.jsx
+++ b/src/js/components/campaignpage/CampaignPage.jsx
@@ -312,7 +312,8 @@ const scaleCharityDonations = (campaign, donationTotal, donation4charityUnscaled
 const CampaignPage = () => {
 	let {
 		via,
-		landing,
+        landing,
+        showNonServed
 	} = DataStore.getValue(['location', 'params']) || {};
 	// What adverts etc should we look at?
 	let {pvTopItem, pvTopCampaign, pvCampaigns, pvAds, pvAdvertisers, pvAgencies} = fetchIHubData();
@@ -571,7 +572,8 @@ const CampaignPage = () => {
 						viewcount4campaign={viewcount4campaign}
 						donationTotal={donationTotal}
 						nvertiserName={nvertiserName}
-						totalViewCount={totalViewCount}
+                        totalViewCount={totalViewCount}
+                        showNonServed={showNonServed}
 					/>
 				)}
 


### PR DESCRIPTION
…can be hidden
Found ads before this would only be hidden if no top/master campaign was set, which worked for a while because that was the case for several pages, so I have changed the behaviour to always merge the hide ads list to prevent some ads being unhideable