### PR TITLE
Show which campaign pages are being visited in Google Analytics

### DIFF
--- a/src/js/components/HashWatcher.jsx
+++ b/src/js/components/HashWatcher.jsx
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+
+/** Construct a normalised non-hash path for analytics purposes */
+const syntheticPath = (url) => {
+	if (!url) return null;
+	const urlObj = new URL(url);
+	const hash = urlObj.hash || '#my';
+	let [hashBase, hashParams = ''] = hash.split('?');
+	hashBase = hashBase.replace(/^#/, '');
+	
+	if ('campaign' === hashBase) {
+		const params = new URLSearchParams(hashParams);
+		let vertId = params.get('gl.vert');
+		let cmpId = params.get('gl.campaign');
+		if (vertId) return `${hashBase}/vert/${vertId}`;
+		if (cmpId) return `${hashBase}/cmp/${cmpId}`
+	}
+	return hashBase;
+}
+
+/** Check changed hash and send a synthetic pageview if the change constitutes a new page */
+const onHashChange = (event) => {
+	const oldUrl = syntheticPath(event.oldURL);
+	const newUrl = syntheticPath(event.newURL);
+
+	if (oldUrl !== newUrl) {
+		ga('set', 'page', newUrl);
+		ga('send', 'pageview');
+	}
+}
+
+/** Dummy component: watches for hash changes and logs to Google Analytics */
+const HashWatcher = () => {
+	useEffect(() => {
+		window.addEventListener('hashchange', onHashChange);
+		onHashChange(null, window.location.href);
+		return () => window.removeEventListener('hashchange', onHashChange);
+	}, [])
+	return null;
+}
+
+export default HashWatcher;

--- a/src/js/components/MainDiv.jsx
+++ b/src/js/components/MainDiv.jsx
@@ -34,6 +34,7 @@ import { getAllXIds } from '../base/data/Person';
 import NewtabCharityLogin from './pages/NewtabCharityLogin';
 import ServerIO from '../plumbing/ServerIO';
 import { track } from '../base/plumbing/log';
+import HashWatcher from './HashWatcher';
 // import RedesignPage from './pages/RedesignPage';
 
 // DataStore
@@ -144,7 +145,7 @@ class MainDiv extends Component {
 	render() {
 		let path = DataStore.getValue('location', 'path');	
 		let page = (path && path[0]);
-		if ( ! page) {
+		if (!page) {
 			modifyHash([DEFAULT_PAGE]);
 			return null;
 		}
@@ -178,6 +179,7 @@ class MainDiv extends Component {
 		return (
 			<>
 				<div id={page} /* wrap in an id in case you need high-strength css rules */>
+					<HashWatcher />
 					<Page path={path} spring={spring}/>
 					<Footer />
 				</div>

--- a/web/index.html
+++ b/web/index.html
@@ -54,6 +54,9 @@
 				fjs.parentNode.insertBefore(js, fjs);
 			}(document, 'script', 'facebook-jssdk'));
 		</script>
+
+
+	
 		
 		<!-- everything comes via webpack -->
 		<script>
@@ -72,16 +75,27 @@
 			var filename = isDebug ? 'bundle-debug.js' : 'bundle.js';
 			document.write('<script src="/build/js/' + filename + '"/><\/script>');
 		</script>
-		
-		<!-- Global site tag (gtag.js) - Google Analytics -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-89730678-7"></script>
+
+		<!-- Google Analytics -->
 		<script>
+			window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+			ga('create', 'UA-89730678-7', 'auto');
+			// Don't send initial pageview - HashWatcher.jsx will translate hash to a more informative synthetic URL.
+			// ga('send', 'pageview');
+		</script>
+		<script async src='https://www.google-analytics.com/analytics.js'></script>
+		<!-- End Google Analytics -->
+		
+		<!-- Experiment: Send synthetic pageview events with more useful normalised URLs using Google Analytics API above-->
+		<!-- Global site tag (gtag.js) - Google Analytics -->
+		<!-- script async src="https://www.googletagmanager.com/gtag/js?id=UA-89730678-7"></script -->
+		<!-- script>
 		window.dataLayer = window.dataLayer || [];
 		function gtag(){dataLayer.push(arguments);}
 		gtag('js', new Date());
 
 		gtag('config', 'UA-89730678-7');
-		</script>
+		</script -->
 		<!-- script async src='//as.good-loop.com/pxl.js'></script -->
 		<img src='//lg.good-loop.com/pxl' style='position:absolute;bottom:0px;left:0px;width:1;height:1;'/>
 	</body>


### PR DESCRIPTION
HashWatcher.jsx creates synthetic page URLs in the pattern...
`#my` ⟶ `/my`
`#campaign` ⟶ `/campaign`
`#campaign?gl.vert=xxxxx` ⟶ `/campaign/vert/xxxxx`
`#campaign?gl.campaign=yyyyy` ⟶ `/campaign/cmp/yyyyy`
...and logs changes in this virtual URL to Google Analytics, as (a) hashes aren't logged by the normal Google tag, and (b) hash changes don't automatically trigger a pageview event.