### PR TITLE
hide extended description row, so that if that isn't set we don't see…

### DIFF
--- a/src/js/components/pages/CharityLandingPage.jsx
+++ b/src/js/components/pages/CharityLandingPage.jsx
@@ -47,21 +47,24 @@ const HelpCharityTogetherCard = ({ngo}) => {
 				<T4GCTA className="w-100"/>
 			</Col>
 		</Row>
-		<Row className='mt-5 pt-5'>
-			<Col className="d-md-none" md={6}>
-				<NGOImage ngo={ngo} className="w-100" imgIdx={2}/>
-			</Col>
-			<Col md={6} className='p-5 d-flex flex-column justify-content-between'>
-				<div>
-					<h3>Together we'll do more</h3>
-					<NGODescription ngo={ngo} extended/>
-				</div>
-				<T4GCTA className="w-100"/>
-			</Col>
-			<Col className="d-none d-md-block" md={6}>
-				<NGOImage ngo={ngo} className="w-100" imgIdx={2}/>
-			</Col>
-		</Row>
+
+		{ngo.extendedDescription && 
+			<Row className='mt-5 pt-5'>
+				<Col className="d-md-none" md={6}>
+					<NGOImage ngo={ngo} className="w-100" imgIdx={2}/>
+				</Col>
+				<Col md={6} className='p-5 d-flex flex-column justify-content-between'>
+					<div>
+						<h3>Together we'll do more</h3>
+						<NGODescription ngo={ngo} extended/>
+					</div>
+					<T4GCTA className="w-100"/>
+				</Col>
+				<Col className="d-none d-md-block" md={6}>
+					<NGOImage ngo={ngo} className="w-100" imgIdx={2}/>
+				</Col>
+			</Row>
+		}
 		{/*
 		<Row className='mb-4 mt-5 pt-5'>
 			{isPortraitMobile() ? secondSection.reverse() : secondSection}


### PR DESCRIPTION
… duplicate text

Hello @dodo721,

This PR will hide the second "together we'll do more..." row on the charity landing page if the extended description isn't set (as spotted by Hannah). Example seen here (and on any charity without an extended description set): https://my.good-loop.com/charity/oxfam.html

You can see that the text under "What Oxfam is doing" and "Together we'll do more" is duplicated - I don't think this looks too good. It _would_ be possible to go through every single charity and set this manually, but I think this is a good interim fix.
