### PR TITLE
LeftSidebar - option to hide on mobile screens; add account links to …

### DIFF
--- a/src/js/components/MainDiv.jsx
+++ b/src/js/components/MainDiv.jsx
@@ -44,6 +44,8 @@ import { MyLoginWidgetGuts } from './MyLoginWidgetGuts';
 import BlogContent from './pages/BlogContent';
 import SafariPage from './pages/SafariPage';
 // import TestPage from './pages/TestPage';
+import { label4tab } from './pages/AccountPage';
+import { getScreenSize } from '../base/utils/miscutils';
 
 // DataStore
 C.setupDataStore();
@@ -104,15 +106,29 @@ Login.app = C.app.id;
 Login.dataspace = C.app.dataspace;
 
 const MainDiv = () => {
+	let navPageLinks = {};
+	let navPageLabels = {};
 
-	const navPageLinks = {
+	// If the user is logged in, and is on mobile, then push account/dashboard etc links to the top of
+	// the navbar dropdown.
+	const screenSize = getScreenSize();
+	if (Login.isLoggedIn() && (screenSize == "sm" || screenSize == "xs")) {
+		for (const [link, label] of Object.entries(label4tab)) {
+			navPageLinks[`account?tab=${link}`] = [];
+			navPageLabels[label] = [];
+		};
+	}
+
+	navPageLinks = {
+		...navPageLinks,
 		"ourstory":[],
 		"our-impact": ['charities', 'impactoverview', 'green'],
 		'tabsforgood':[],
 		// "blog":[]
 	};
 
-	const navPageLabels = {
+	navPageLabels = {
+		...navPageLabels,
 		"Our Story":[],
 		"Our Impact": ['Charity Impact', 'Impact Hub', 'Green Media'],
 		"Tabs for Good":[],
@@ -121,13 +137,11 @@ const MainDiv = () => {
 
 	// HACK hide whilst we finish it
 	if ( ! Roles.isTester()) {
-
 		delete navPageLinks["our-impact"].green;
 		delete navPageLabels["Our Impact"]["Green Media"];
 
 		// delete navPageLinks["blog"];
 		// delete navPageLabels["Blog"];
-		
 	}
 
 	return (<MainDivBase

--- a/src/js/components/pages/AccountPage.jsx
+++ b/src/js/components/pages/AccountPage.jsx
@@ -6,7 +6,7 @@ import { LoginLink } from '../../base/components/LoginWidget';
 import Person, { getAllXIds, getEmail, getProfile, hasConsent, PURPOSES } from '../../base/data/Person';
 import DataStore from '../../base/plumbing/DataStore';
 import { lg } from '../../base/plumbing/log';
-import { space } from '../../base/utils/miscutils';
+import { getScreenSize, space } from '../../base/utils/miscutils';
 import Login from '../../base/youagain';
 import SubscriptionBox from '../cards/SubscriptionBox';
 import ShareButton from '../ShareButton';
@@ -41,8 +41,8 @@ const Account = () => {
 	</>;
 };
 
-const label4tab = {
-	dashboard: 'Dashboard',
+export const label4tab = {
+	dashboard: "Dashboard",
 	account: "My Account",
 	settings: "Settings",
 	tabsForGood: "Tabs for Good"
@@ -72,7 +72,7 @@ const Page = () => {
 	return (<>
 		<div className="AccountPage avoid-navbar">
 			<Editor3ColLayout>
-				<LeftSidebar>
+				<LeftSidebar hideOnMobile>
 					<div className="account-sidebar pl-3">
 						<h5 className="p-2">My Good-Loop</h5>
 						{Object.keys(label4tab).map(t => <SidebarTabLink key={t} tab={t} label={label4tab[t]} selected={t === tab} />)}


### PR DESCRIPTION
Hello @Wing,

This PR will move the account settings links to the main navbar when on a mobile device so that they appear under the hamburger menu instead of the floating menu to the left. See also: [wwappbase.js/pull/82](https://github.com/good-loop/wwappbase.js/pull/82).

This feels a bit hacky honestly.. and I think there may be a better way to do this. What do you think?

Aidan