### PR TITLE
move account page settings links to navbar dropdown on mobile displays

### DIFF
--- a/src/js/components/MainDiv.jsx
+++ b/src/js/components/MainDiv.jsx
@@ -43,9 +43,9 @@ import { T4GCTA, T4GSignUpModal, T4GPluginButton } from './T4GSignUp';
 import { MyLoginWidgetGuts } from './MyLoginWidgetGuts';
 import BlogContent from './pages/BlogContent';
 import SafariPage from './pages/SafariPage';
+import { mobileNavAccountMenuItems } from './pages/AccountPage';
 // import TestPage from './pages/TestPage';
-import { label4tab } from './pages/AccountPage';
-import { isMobile } from '../base/utils/miscutils';
+// 
 
 // DataStore
 C.setupDataStore();
@@ -106,33 +106,22 @@ Login.app = C.app.id;
 Login.dataspace = C.app.dataspace;
 
 const MainDiv = () => {
-	let navPageLinks = {};
-	let navPageLabels = {};
-
-	// If the user is logged in, and is on mobile, then push account/dashboard etc links to the top of
-	// the navbar dropdown.
-	if (Login.isLoggedIn() && isMobile()) {
-		for (const [link, label] of Object.entries(label4tab)) {
-			navPageLinks[`account?tab=${link}`] = [];
-			navPageLabels[label] = [];
-		};
-	}
-
-	navPageLinks = {
-		...navPageLinks,
+	const navPageLinks = {
 		"ourstory":[],
 		"our-impact": ['charities', 'impactoverview', 'green'],
 		'tabsforgood':[],
 		// "blog":[]
 	};
 
-	navPageLabels = {
-		...navPageLabels,
+	const navPageLabels = {
 		"Our Story":[],
 		"Our Impact": ['Charity Impact', 'Impact Hub', 'Green Media'],
 		"Tabs for Good":[],
 		// "Blog":[]
 	};
+
+	// 
+	const navbarAccountMenuItems = mobileNavAccountMenuItems;
 
 	// HACK hide whilst we finish it
 	if ( ! Roles.isTester()) {
@@ -151,6 +140,7 @@ const MainDiv = () => {
 		navbarDarkTheme={false}
 		navbarChildren={() => <><T4GCTA>Get Tabs for Good on Desktop</T4GCTA><T4GSignUpModal /></>}
 		navbarBackgroundColour="white"
+		navbarAccountMenuItems={mobileNavAccountMenuItems}
 		NavExpandSize="md"
 		// navbarLabels={getNavbarLabels}
 		fullWidthPages={["impact", 'home', 'charity', 'tabsforgood', 'account', 'green', 'charities', 'impactoverview', 'campaign', 'ourstory', 'ads', 'blog', 'blogcontent', 'allowlist', 'safari']}

--- a/src/js/components/MainDiv.jsx
+++ b/src/js/components/MainDiv.jsx
@@ -120,9 +120,6 @@ const MainDiv = () => {
 		// "Blog":[]
 	};
 
-	// 
-	const navbarAccountMenuItems = mobileNavAccountMenuItems;
-
 	// HACK hide whilst we finish it
 	if ( ! Roles.isTester()) {
 		delete navPageLinks["our-impact"].green;

--- a/src/js/components/pages/AccountPage.jsx
+++ b/src/js/components/pages/AccountPage.jsx
@@ -51,15 +51,15 @@ const label4tab = {
 
 export const mobileNavAccountMenuItems = isMobile() ? <>
 		<DropdownItem>
-			<a href="/#account" className="nav-link">Dashboard</a>  
+			<a href="/account" className="nav-link">Dashboard</a>  
 		</DropdownItem>
 		<DropdownItem divider />
 		<DropdownItem>
-			<a href="/#account?tab=settings" className="nav-link">Settings</a> 
+			<a href="/account?tab=settings" className="nav-link">Settings</a> 
 		</DropdownItem>
 		<DropdownItem divider />
 		<DropdownItem>
-			<a href="/#account?tab=tabsForGood" className="nav-link">Tabs-for-Good Settings</a> 
+			<a href="/account?tab=tabsForGood" className="nav-link">Tabs-for-Good Settings</a> 
 		</DropdownItem>
 	</> : null;
 

--- a/src/js/components/pages/AccountPage.jsx
+++ b/src/js/components/pages/AccountPage.jsx
@@ -6,14 +6,15 @@ import { LoginLink } from '../../base/components/LoginWidget';
 import Person, { getAllXIds, getEmail, getProfile, hasConsent, PURPOSES } from '../../base/data/Person';
 import DataStore from '../../base/plumbing/DataStore';
 import { lg } from '../../base/plumbing/log';
-import { getScreenSize, space } from '../../base/utils/miscutils';
+import { getScreenSize, isMobile, space } from '../../base/utils/miscutils';
 import Login from '../../base/youagain';
 import SubscriptionBox from '../cards/SubscriptionBox';
 import ShareButton from '../ShareButton';
 import AccountSettings from './AccountSettings';
 import TabsForGoodSettings from './TabsForGoodSettings';
 import C from '../../C';
-import MyDataDashboard from '../mydata/MyDataDashboard'
+import MyDataDashboard from '../mydata/MyDataDashboard';
+import { DropdownItem } from 'reactstrap';
 
 
 const Account = () => {
@@ -41,12 +42,26 @@ const Account = () => {
 	</>;
 };
 
-export const label4tab = {
+const label4tab = {
 	dashboard: "Dashboard",
 	account: "My Account",
 	settings: "Settings",
 	tabsForGood: "Tabs for Good"
 };
+
+export const mobileNavAccountMenuItems = isMobile() ? <>
+		<DropdownItem>
+			<a href="/#account" className="nav-link">Dashboard</a>  
+		</DropdownItem>
+		<DropdownItem divider />
+		<DropdownItem>
+			<a href="/#account?tab=settings" className="nav-link">Settings</a> 
+		</DropdownItem>
+		<DropdownItem divider />
+		<DropdownItem>
+			<a href="/#account?tab=tabsForGood" className="nav-link">Tabs-for-Good Settings</a> 
+		</DropdownItem>
+	</> : null;
 
 const Page = () => {
 	// handle the not-logged-in case


### PR DESCRIPTION
Hello @winterstein,

This PR will move the dashboard / settings / t4g settings links on `/#account` into the Navbar on mobile devices. These will appear under the account menu, between the "Account" and "Logout" items.

There's probably a much more elegant way to achieve what I'm trying to do, please let me know if there's anything I could have done better, it will help me learn. :)

NB: I think this might break something on Firefox (I see `TypeError: itemValue is null` - not 100% sure if it's related), but I can't quite figure out what. It works fine on Chrome. 

See also: [wwappbase.js/pull/83](https://github.com/good-loop/wwappbase.js/pull/83)