### PR TITLE
possbile workaround to logout

### DIFF
--- a/src/js/components/MainDiv.jsx
+++ b/src/js/components/MainDiv.jsx
@@ -50,6 +50,7 @@ import OurImpactPage from './pages/OurImpactPage';
 import TabsForGoodProductPage from './pages/TabsForGoodProductPage';
 
 import GenerateGreenDemoEvents from './pages/GenerateGreenDemoEvents';
+import LogoutPage from './pages/LogoutPage';
 
 // DataStore
 C.setupDataStore();
@@ -99,6 +100,7 @@ const PAGES = {
 	getinvolved: GetInvolvedPage,
 	ourimpact: OurImpactPage,
 	ggde: GenerateGreenDemoEvents,
+	logout: LogoutPage, // Logout Page for T4G
 };
 
 // ?? switch to router??

--- a/src/js/components/NewTabMainDiv.jsx
+++ b/src/js/components/NewTabMainDiv.jsx
@@ -389,6 +389,11 @@ const UserControls = ({ cid }) => {
     </div>
   );
 
+  const T4GLogoutLink = () => <a href={'#'} className={"LogoutLink"} 
+  onClick={() => top.location.href = ServerIO.MYLOOP_ENDPOINT + '/logout'}>
+    Logout
+  </a>;
+
   return (
     <>
       {showMyloopLink && myloopLink}
@@ -397,6 +402,7 @@ const UserControls = ({ cid }) => {
         accountMenuItems={accountMenuItems}
         linkType='a'
         small
+        logoutLink= {<T4GLogoutLink/>}
         customLogin={() => (
           <NewtabLoginLink className='login-menu btn btn-transparent fill'>
             Register / Log in

--- a/src/js/components/pages/LogoutPage.jsx
+++ b/src/js/components/pages/LogoutPage.jsx
@@ -1,0 +1,16 @@
+import React, { useEffect } from 'react';
+import Login from '../../base/youagain';
+
+/**
+ * A url to directly log you out. This is a hack to logout in T4G without HTTPS. Do not use this page in other use cases. 
+ */
+const LogoutPage = () => {
+	useEffect(() => {
+		if (Login.isLoggedIn()) Login.logout();
+		window.location.href = "/home";
+		}, []);
+
+  return <></>;
+};
+
+export default LogoutPage;


### PR DESCRIPTION
A workaround. 
T4G logout will not work possibly because of HTTPS issue. This workaround redirect the user to my-loop and log them out instantly, redirecting them back to home page of my-loop. 
Good idea? 