### PR TITLE
add download button to greendash widgets

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "easy-enums": "^1.1.8",
     "easyi18n": "^1.1.1",
     "fast-json-patch": "^3.1.0",
+    "html2canvas": "^1.4.1",
     "intl": "^1.2.5",
     "jquery": "^3.6.0",
     "js-cookie": "^2.2.1",
@@ -96,4 +97,3 @@
     "testTimeout": 10000
   }
 }
-

--- a/src/js/components/pages/greendash/GreenMetrics.jsx
+++ b/src/js/components/pages/greendash/GreenMetrics.jsx
@@ -58,7 +58,7 @@ const OverviewWidget = ({period, data}) => {
 
 
 const CTACard = ({}) => {
-	return <GreenCard className="carbon-cta flex-column">
+	return <GreenCard className="carbon-cta flex-column" downloadable={false}>
 		<div className="cta-card-decoration">
 			<img className="tree-side" src="/img/green/tree-light.svg" />
 			<img className="tree-centre" src="/img/green/tree-light.svg" />

--- a/src/js/components/pages/greendash/dashutils.js
+++ b/src/js/components/pages/greendash/dashutils.js
@@ -224,6 +224,13 @@ const DownloadButton = ({className}) => {
 					document.querySelectorAll('.widget-export').forEach(node => {
 						node.style.display = 'none';
 					});
+
+					// Larger headings
+					Object.assign(document.querySelector('.gc-title').style,{
+						fontSize:'1.25rem',
+						textAlign: 'center',
+						fontWeight: 'bold',
+					});
 				},
 				scale: 1.25
 			}).then(canvas => {

--- a/src/js/components/pages/greendash/dashutils.js
+++ b/src/js/components/pages/greendash/dashutils.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Button, Card } from 'reactstrap';
+import html2canvas from 'html2canvas';
 
 import DataStore from "../../../base/plumbing/DataStore";
 import { isoDate, space } from '../../../base/utils/miscutils';
@@ -187,10 +188,58 @@ const yearRegex = /^(\d\d?\d?\d?)$/;
 const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
 
+const saveAs = (uri, filename) => {
+    var link = document.createElement('a');
+
+    if (typeof link.download === 'string') {
+        link.href = uri;
+        link.download = filename;
+
+        // Firefox requires the link to be in the body
+        document.body.appendChild(link);
+
+        link.click();
+
+        // Remove the link when done
+        document.body.removeChild(link);
+    } else {
+        window.open(uri);
+    }
+}
+
+const DownloadButton = ({className}) => {
+	return (
+		<a className="gc-title widget-export" onClick={e => {
+			e.preventDefault();
+			html2canvas(document.querySelector(`.${className}`), {
+				// TODO
+				// html2canvas doesn't work well with elements which have a `box-shadow` property.
+				// I tried to remove that property by looping through all child nodes in the DOM,
+				// and running node.style.removeProperty('box-shadow') - but that didn't work.
+				// 
+				// Instead, for whatever reason, setting the scale to 1.25 makes things render properly.
+				// Albeit, the text is a tiny bit blurry.
+				onclone: document => {
+					// Hide the download button in the exported image
+					document.querySelectorAll('.widget-export').forEach(node => {
+						node.style.display = 'none';
+					});
+				},
+				scale: 1.25
+			}).then(canvas => {
+				saveAs(canvas.toDataURL(), `${className}.png`);
+			});
+		}}>&#128229; Download</a>
+	);
+}
+
 /** Boilerplate styling for a subsection of the green dashboard */
-export const GreenCard = ({ title, children, className, row, ...rest}) => {
+export const GreenCard = ({ title, children, className, row, downloadable=true, ...rest}) => {
 	return <div className={space('green-card my-2 flex-column', className)} {...rest}>
 		{title ? <h6 className="gc-title">{title}</h6> : null}
+		
+		{downloadable ? <DownloadButton className={className} /> : null}
+
 		<Card body className={space('gc-body', row ? 'flex-row' : 'flex-column')}>{children}</Card>
 	</div>
 };

--- a/src/js/components/pages/greendash/dashutils.js
+++ b/src/js/components/pages/greendash/dashutils.js
@@ -220,9 +220,27 @@ const DownloadButton = ({className}) => {
 				// Instead, for whatever reason, setting the scale to 1.25 makes things render properly.
 				// Albeit, the text is a tiny bit blurry.
 				onclone: document => {
+					// The greenCard widget we're tacking a screenshot of.
+					// This is in the cloned document, so modifying it won't affect what the user sees.
+					const greenCard = document.querySelector(`.${className}`);
+
 					// Hide the download button in the exported image
 					document.querySelectorAll('.widget-export').forEach(node => {
 						node.style.display = 'none';
+					});
+
+					// Hide download CSV button on 'your journey so far' card
+					Object.assign(greenCard.querySelector('a[download="table.csv"]').style, {
+						display: 'none'
+					});
+
+					// Hide impact overview button on 'your journey so far card'
+					greenCard.querySelectorAll('a').forEach(node => {
+						if (node.textContent.includes('Impact Overview')) {
+							Object.assign(node.style, {
+								display: 'none'
+							});
+						}
 					});
 
 					// Larger headings
@@ -231,10 +249,16 @@ const DownloadButton = ({className}) => {
 							fontSize:'1.25rem',
 							textAlign: 'center',
 							fontWeight: 'bold',
+							marginBottom: '8px'
 						});
 					});
+
+					// Card padding
+					Object.assign(greenCard.style, {
+						padding: '20px'
+					});
 				},
-				scale: 1.25
+				scale: 1.25,
 			}).then(canvas => {
 				saveAs(canvas.toDataURL(), `${className}.png`);
 			});

--- a/src/js/components/pages/greendash/dashutils.js
+++ b/src/js/components/pages/greendash/dashutils.js
@@ -226,10 +226,12 @@ const DownloadButton = ({className}) => {
 					});
 
 					// Larger headings
-					Object.assign(document.querySelector('.gc-title').style,{
-						fontSize:'1.25rem',
-						textAlign: 'center',
-						fontWeight: 'bold',
+					document.querySelectorAll('.gc-title').forEach(node => {
+						Object.assign(node.style, {
+							fontSize:'1.25rem',
+							textAlign: 'center',
+							fontWeight: 'bold',
+						});
 					});
 				},
 				scale: 1.25


### PR DESCRIPTION
Hello @roscoemcinerney,

This PR will add a download button to each Green Dashboard widget. It uses `html2canvas` to create a canvas element for a given widget, which can then be exported as an image.

Some caveats:

- Sizing isn't consistent. The size of the final image will depend on the browser viewport.
- Text is slightly blurry. `html2canvas` doesn't work well when elements have a `box-shadow` CSS property, they won't render properly. I tried to remove that property in the cloned document, but couldn't get it to work for some reason. I discovered that setting `scale` to `1.25` for, whatever reason, fixes the rendering issue - but this makes some text ever so slightly blurry.

Also not sure how well this will work on mobile.

- Aidan
