### PR TITLE
performance update draft

### DIFF
--- a/src/js/components/pages/greendash/BreakdownCardEmissions.jsx
+++ b/src/js/components/pages/greendash/BreakdownCardEmissions.jsx
@@ -9,7 +9,7 @@ import { CO2e, dataColours, GreenCard, GreenCardAbout, ModeButton, NOEMISSIONS, 
 import SimpleTable, { Column } from '../../../base/components/SimpleTable';
 import List from '../../../base/data/List';
 import { ButtonGroup } from 'reactstrap';
-import { emissionsPerImpressions, getBreakdownByEmissions, getCompressedBreakdown, getSumColumnEmissions, getTagsEmissions } from './emissionscalc';
+import { emissionsPerImpressions, getBreakdownByEmissions, getCompressedBreakdown, getSumColumnEmissions, getTagsEmissions, getCarbonEmissions } from './emissionscalc';
 import { isPer1000 } from './GreenMetricsEmissions';
 // Doesn't need to be used, just imported so MiniCSSExtractPlugin finds the LESS
 import CSS from '../../../../style/greendash-breakdown-card.less';
@@ -257,7 +257,26 @@ const PubSubcard = ({data}) => {
  * @param {Object} p
  * @param {Object} p.dataValue pvChartData.value Which are split by breakdown: os, adid, 
  */
-const BreakdownCardEmissions = ({ dataValue }) => {
+const BreakdownCardEmissions = ({baseFilters}) => {
+	let dataValue;
+
+	/**
+	 * Easy way: fetching everything here
+	 * This is stil a big load, could take over 16 seconds
+	 * TODO: 1. adid & domain only need count + co2, no need for the whole emissions bucket
+	 * TODO: 2. lazyload it, only load when user get to the page
+	 */
+	const pvDataValue = getCarbonEmissions({...baseFilters, 
+		breakdown: [
+			'total{"emissions":"sum"}', 
+			'os{"co2":"sum"}',
+			'adid{"emissions":"sum"}',
+			'domain{"emissions":"sum"}'
+		]
+	})
+
+	if (pvDataValue.resolved && pvDataValue.value) dataValue = pvDataValue.value;
+
 	if (!dataValue) return <Misc.Loading text="Fetching your data..." />;
 	const [mode, setMode] = useState('tech');
 

--- a/src/js/components/pages/greendash/CompareCardEmissions.jsx
+++ b/src/js/components/pages/greendash/CompareCardEmissions.jsx
@@ -31,7 +31,7 @@ const baseOptions = (unit='kg') => ({
 });
 
 
-const QuartersCard = ({baseFilters, dataValue}) => {
+const QuartersCard = ({baseFilters}) => {
 	// Set up base chart data object
 	const chartProps = {
 		data: {
@@ -58,7 +58,7 @@ const QuartersCard = ({baseFilters, dataValue}) => {
 		...baseFilters,
 		start: isoDate(quarter.start),
 		end: isoDate(quarter.end),
-		breakdown: 'total{"emissions":"sum"}',
+		breakdown: 'total{"co2":"sum"}',
 	}));
 	// add it into chartProps
 	pvsBuckets.forEach((pvBuckets, i) => {
@@ -110,7 +110,7 @@ const CampaignCard = ({baseFilters}) => {
 	const pvChartData = getCarbonEmissions({
 		...baseFilters,
 		breakdown: [
-			'campaign{"emissions":"sum"}',
+			'campaign{"co2":"sum"}',
 		],
 		name:"campaign-chartdata"
 	});
@@ -147,13 +147,13 @@ const CampaignCard = ({baseFilters}) => {
 };
 
 
-const CompareCardEmissions = ({dataValue, ...props}) => {
+const CompareCardEmissions = ({...props}) => {
 	const [mode, setMode] = useState('quarter');
 	// TODO don't offer campaign biew if we're focuding on one campaign
 	const campaignModeDisabled = !! DataStore.getUrlValue("campaign");
 
 	const subcard = (mode === 'quarter') ? (
-		<QuartersCard dataValue={dataValue} {...props} />
+		<QuartersCard {...props} />
 	) : (
 		<CampaignCard {...props} />
 	);

--- a/src/js/components/pages/greendash/JourneyCardEmissions.jsx
+++ b/src/js/components/pages/greendash/JourneyCardEmissions.jsx
@@ -7,7 +7,7 @@ import DataStore from '../../../base/plumbing/DataStore';
 import { A } from '../../../base/plumbing/glrouter';
 import { encURI } from '../../../base/utils/miscutils';
 import printer from '../../../base/utils/printer';
-import { getCarbonEmissions, getOffsetsByTypeEmissions } from './emissionscalc';
+import { getOffsetsByTypeEmissions } from './emissionscalc';
 import { GreenCard, GreenCardAbout, Mass } from './dashutils';
 import { getDataItem } from '../../../base/plumbing/Crud';
 import KStatus from '../../../base/data/KStatus';


### PR DESCRIPTION
There are still room of improvement inside of `BreakdownCardEmissions` but this should already give a huge improvement to the UX by cutting down the initial load time. 

https://my.good-loop.com/greendash?campaign=iLWiEWO6&period=2022-Q4
Speed up the initial loading time of this page from 18+ seconds to within 4 seconds. (BreakdownCard still need 15 seconds to load, but this sub card won't stop from other parts of the dashboard to load anymore)