### PR TITLE
Green dashboard: Restore old columns on CSV export

### DIFF
--- a/src/js/components/pages/greendash/GreenMetrics.jsx
+++ b/src/js/components/pages/greendash/GreenMetrics.jsx
@@ -222,7 +222,6 @@ const GreenMetrics2 = ({}) => {
 				<Col xs="12" sm="4" className="flex-column">
 					<JourneyCard
 						campaigns={List.hits(pvCampaigns?.value)}
-						dataByTime={pvChartData.value?.by_time.buckets}
 						{...commonProps}
 						emptyTable={emptyTable || noData}
 					/>


### PR DESCRIPTION
Before the big precalculated emissions refactor, the "Your Journey" card used to have a table available with a complete all-variables cross-breakdown - and a button to download it. This adds back a CSV download with the same column set.