### PR TITLE
Green dashboard: silence a console error

### DIFF
--- a/src/js/components/pages/greendash/GreenDashboardFilters.jsx
+++ b/src/js/components/pages/greendash/GreenDashboardFilters.jsx
@@ -260,7 +260,7 @@ const GreenDashboardFilters = ({}) => {
 
 	// Populate the filter-by-item dropdown based on user shares & access level
 	useEffect(() => {
-		getFilterItems({filterMode, setFilterItems});
+		if (filterMode) getFilterItems({filterMode, setFilterItems});
 	}, [Login.getId(), filterMode]);
 
 	// TODO "Normal" access control:


### PR DESCRIPTION
The dashboard filter was firing a harmless but alarming console error when it attempted to populate the filter-by-item dropdown before the user selected which type of item to filter on - this guards against that.