### PR TITLE
Fix issue where charity logo shoves hamburger out of navbar

### DIFF
--- a/src/style/navbar.less
+++ b/src/style/navbar.less
@@ -19,10 +19,14 @@
     }
 
     .brand-logo {
+        height: 50px;
+        object-fit: contain;
         @media @md-min {
             position: relative;
             top: 2px;
-            max-height: 50px;
+        }
+        @media @width-mobile {
+          max-width: 85px;
         }
     }
 


### PR DESCRIPTION
Gives the logo a fixed height (SVG logos don't necessarily take up that space without being told) and restricts width on mobile sizes.