### PR TITLE
Bugfix/2023 02/account menu layout

### DIFF
--- a/src/js/components/pages/greendash/GreenNavBar.jsx
+++ b/src/js/components/pages/greendash/GreenNavBar.jsx
@@ -8,6 +8,7 @@ import Campaign from '../../../base/data/Campaign';
 import KStatus from '../../../base/data/KStatus';
 import { getDataItem } from '../../../base/plumbing/Crud';
 import Roles from '../../../base/Roles';
+import DataStore from '../../../base/plumbing/DataStore';
 
 import { encURI, isMobile, space } from '../../../base/utils/miscutils';
 import C from '../../../C';
@@ -41,10 +42,12 @@ const GreenNavBar = ({active}) => {
 	let pvCampaign = campaignId? getDataItem({type:C.TYPES.Campaign, id:campaignId,status:KStatus.PUB_OR_DRAFT, swallow:true}) : {};
 	let impactUrl = pvCampaign.value? '/green/'+encURI(pvCampaign.value.id) : '/green';
 
+	const debug = DataStore.getUrlValue("debug") || DataStore.getUrlValue("gl.debug");
+
 	// We don't use the standard <Collapse> pattern here because that doesn't support an always-horizontal navbar
 
 	return (<>
-		{Roles.isDev() && <AccountMenu />}
+		{(Roles.isDev() || debug) && <AccountMenu className="float-left" noNav />}
 	<Navbar dark expand="md" id="green-navbar" className={space('flex-column', 'justify-content-start', isOpen && 'mobile-open')}>
 		<NavbarToggler onClick={toggle} />
 		<Nav navbar vertical>

--- a/src/js/components/pages/greendash/GreenNavBar.jsx
+++ b/src/js/components/pages/greendash/GreenNavBar.jsx
@@ -10,7 +10,7 @@ import { getDataItem } from '../../../base/plumbing/Crud';
 import Roles from '../../../base/Roles';
 import DataStore from '../../../base/plumbing/DataStore';
 
-import { encURI, isMobile, space } from '../../../base/utils/miscutils';
+import { encURI, isMobile, space, toTitleCase } from '../../../base/utils/miscutils';
 import C from '../../../C';
 import ServerIO from '../../../plumbing/ServerIO';
 const A = C.A;
@@ -42,12 +42,13 @@ const GreenNavBar = ({active}) => {
 	let pvCampaign = campaignId? getDataItem({type:C.TYPES.Campaign, id:campaignId,status:KStatus.PUB_OR_DRAFT, swallow:true}) : {};
 	let impactUrl = pvCampaign.value? '/green/'+encURI(pvCampaign.value.id) : '/green';
 
-	const debug = DataStore.getUrlValue("debug") || DataStore.getUrlValue("gl.debug");
+	const showShareables = DataStore.getUrlValue("shareables");
+	const showFlags = DataStore.getUrlValue("debug") || DataStore.getUrlValue("gl.debug") || showShareables;
 
 	// We don't use the standard <Collapse> pattern here because that doesn't support an always-horizontal navbar
 
 	return (<>
-		{(Roles.isDev() || debug) && <AccountMenu className="float-left" noNav />}
+		{(Roles.isDev() || showFlags) && <AccountMenu className="float-left" noNav/>}
 	<Navbar dark expand="md" id="green-navbar" className={space('flex-column', 'justify-content-start', isOpen && 'mobile-open')}>
 		<NavbarToggler onClick={toggle} />
 		<Nav navbar vertical>

--- a/src/js/components/pages/greendash/dashutils.js
+++ b/src/js/components/pages/greendash/dashutils.js
@@ -373,6 +373,24 @@ export const dataColours = (series, maxColour = dfltMaxColour, minColour = dfltM
 	});
 };
 
+/**
+ * 
+ * @returns {{filterMode:filterMode, filterId:string}}
+ */
+export const getFilterModeId = () => {
+	const brandId = DataStore.getUrlValue('brand');
+	const agencyId = DataStore.getUrlValue('agency');
+	const campaignId = DataStore.getUrlValue('campaign');
+	const tagId = DataStore.getUrlValue('tag');
+
+	// What are we going to filter on? ("adid" rather than "tag" because that's what we'll search for in DataLog)
+	// ??shouldn't brand be vertiser??
+	const filterMode = campaignId ? 'campaign' : brandId ? 'brand' : agencyId ? 'agency' : tagId ? 'adid' : null;
+	// Get the ID for the object we're filtering for
+	const filterId = { campaign: campaignId, brand: brandId, agency: agencyId, adid: tagId }[filterMode];
+	return {filterMode, filterId};
+};
+
 /** Minimum kg value where we should switch to displaying tonnes instead */
 export const TONNES_THRESHOLD = 1000;
 

--- a/src/style/GreenDashboard.less
+++ b/src/style/GreenDashboard.less
@@ -125,6 +125,13 @@
 	}
 }
 
+.account-menu.float-left {
+	position: absolute;
+	right: 30px;
+	top: 20px;
+	z-index: 10;
+}
+
 .trees {
 	width: 100%;
 	display: flex;


### PR DESCRIPTION
Puts account menu into the top right and adds flags for the share widget
Not moved the share widget into the account menu for now - was causing bugs with the modal opening twice
Flags:
to show share widget - "shareables=true", or any debug flag
to show emails in share widget - "listemails=true"
to show account menu - any debug or the "shareables" flag
Companion PR in wwappbase.js by the same branch name