### PR TITLE
Green dashboard big CSV export - fix unset domains

### DIFF
--- a/src/js/components/pages/greendash/JourneyCard.jsx
+++ b/src/js/components/pages/greendash/JourneyCard.jsx
@@ -68,10 +68,10 @@ const TreesSection = ({ treesPlanted, coralPlanted }) => {
 };
 
 
-const csvBreakdown = 'country/pub/mbl/os/adid/time{"emissions":"sum"}';
+const csvBreakdown = 'country/domain/mbl/os/adid/time{"emissions":"sum"}';
 const csvCols = [
 	{Header: 'Country', accessor: 'country'},
-	{Header: 'Domain', accessor: 'pub'},
+	{Header: 'Domain', accessor: 'domain'},
 	{Header: 'Mobile?', accessor: 'mbl'},
 	{Header: 'OS', accessor: 'os'},
 	{Header: 'Tag ID', accessor: 'adid'},
@@ -90,6 +90,7 @@ const CSVExport = ({baseFilters}) => {
 	if (!isTester()) return null;
 	const [csvSpec, setCsvSpec] = useState(null); // Spec of the last generated CSV export
 	const [tableData, setTableData] = useState(null); // Table data for CSV export
+	const [error, setError] = useState(null); // Error on last requested table
 
 	useEffect(() => {
 		if (!csvSpec) return; // No CSV requested - nothing to do.
@@ -99,17 +100,26 @@ const CSVExport = ({baseFilters}) => {
 		if (!isEqual(csvSpec, baseFilters)) {
 			setTableData(null);
 			setCsvSpec(null);
+			setError(null);
 			return null;
 		}
 
 		// New CSV spec - get table data for it & prepare CSV download.
 		getCarbon({...baseFilters, breakdown: [csvBreakdown]}).promise.then(res => {
 			setTableData(pivotDataLogToRows(res, csvBreakdown));
+		}).catch(xhr => {
+			// TODO Recover by breaking down request?
+			if (xhr.responseText.match('too_many_buckets_exception')) {
+				setError('CSV export too large to generate in one piece - try a shorter time period.');
+			}
 		});
 	}, [baseFilters, csvSpec]);
 
 	// When "Generate" button clicked - register request to generate a CSV for current filter spec
 	const getTable = () => setCsvSpec({...baseFilters});
+
+	// Error on last CSV generate operation
+	if (error) return <span className="text-danger">{error}</span>;
 
 	// No CSV requested - show "Generate" button
 	if (!csvSpec) return <Button className="mt-1" size="xs" color="default" onClick={getTable}>Generate CSV export</Button>;


### PR DESCRIPTION
Changing breakdown from "pub" (almost all unset) to "domain" (many values) makes a too-many-buckets exception from DataLog much more likely, so the export code now also catches that error and suggests the user try a shorter period. (Previous behaviour was to leave the spinner spinning forever)