### PR TITLE
in per1000 mode only show regions with > 1% total emissions

### DIFF
--- a/src/js/components/pages/greendash/MapCard.jsx
+++ b/src/js/components/pages/greendash/MapCard.jsx
@@ -120,9 +120,12 @@ const SVGMap = ({ mapDefs, data, setFocusRegion, svgRef, showLabels, per1000 }) 
 	let tempMapLables = []
 	let totalCarbon = 0;
 	Object.entries(mapDefs.regions).forEach(([id, props]) => {
-		let { carbon = 0, colour = zeroFill } = data?.[id] || {};
-		carbon /= divisor; // If we're displaying tonnes, convert from kg
-		totalCarbon += carbon
+		let { impressions = 0, carbon = 0, colour = zeroFill } = data?.[id] || {};
+		// If we're displaying tonnes, convert from kg
+		carbon /= divisor;
+
+		// if per1000 is on, convert back into just total carbon emission
+		totalCarbon += (per1000 ? (carbon * (impressions / 1000)) : carbon)
 
 		// Don't modify base map with applied fill/stroke!
 		props = { ...props, fill: colour, stroke: '#fff', strokeWidth: mapDefs.svgAttributes.fontSize / 10 };
@@ -153,7 +156,7 @@ const SVGMap = ({ mapDefs, data, setFocusRegion, svgRef, showLabels, per1000 }) 
 		// Tooltip on hover
 		const title = loading ? null : (
 			<title>
-				{props.name}: {carbon.toFixed(2)} {unit} CO2e
+				{props.name}: {carbon.toFixed(2)} {unit} CO2e, {impressions} impressions 
 			</title>
 		);
 
@@ -162,14 +165,18 @@ const SVGMap = ({ mapDefs, data, setFocusRegion, svgRef, showLabels, per1000 }) 
 				{title}
 			</path>
 		);
+
+		// if we're in tonnes, convert carbon into Kg to still ensure the below minimum 100g rule
+		// if per1000 is on, convert back into total carbon emissions
+		let carbonOutput = per1000 ? (carbon * (impressions / 1000)) : carbon * divisor
+
 		// Store temp label <text> elements. Skip regions with less than 100g carbon output. Harsh, I know  
-		// if we're in tonnes, convert carbon into Kg to still ensure the minimum 100g rule
-		if (showLabels && (carbon * divisor) > 0.1 && pathCentres[pathId]) {
+		if (showLabels && carbonOutput > 0.1 && pathCentres[pathId]) {
 			let { cx, cy } = { ...pathCentres[pathId], ...props };
 			const transY = mapDefs.svgAttributes.fontSize / 2;
-
 			tempMapLables.push({
-				carbon:carbon, 
+				carbon:carbon,
+				impressions: impressions, 
 				label:(
 					<g key={`label-${id}`}>
 						<text className="map-label-name" x={cx} y={cy} textAnchor="middle" transform={`translate(0 ${-transY})`} fontWeight="600" style={{pointerEvents:"none"}}>
@@ -187,8 +194,10 @@ const SVGMap = ({ mapDefs, data, setFocusRegion, svgRef, showLabels, per1000 }) 
 	if(showLabels){
 		// for each label we stored, only place the label if that region is responsible for more than 1% of emissions
 		tempMapLables.forEach((region) => {
+			// if per1000 is on, convert total 'carbon / 1000 impressions' back into just total 'carbon'
+			let regionCarbon = per1000 ? (region.carbon * (region.impressions / 1000)) : region.carbon
 			// only show labels for regions responsible for more than 1% of all emissions
-			if(region.carbon > totalCarbon * 0.01){
+			if(regionCarbon > totalCarbon * 0.01){
 				labels.push(region.label)
 			}
 		})


### PR DESCRIPTION
potential fix to this issue, copying explanation in from monday: 

"
found the issue, per1000 co2 emissions between regions were far more uniform than the default total co2 emissions. For example, both Austrailia and Kenya have similiar values of ~0.4 kg / 1000, however they have 12,650,775 and 7﻿ impressions ﻿﻿respectively.
﻿
﻿Added a potential fix as if we're in per1000 mode, we convert back into total emissions when checking if a region is responsible for > ﻿1% and if it is, show that regions CO2 / 1000 impressions.

﻿

﻿﻿This approach does mean the map can look a little confusing unless you're aware this is happening as some regions will have drastically higher CO2/1000 but won't be labelled as the total CO2 they aren't responsible for > 1% of the total. A potential fix is to add another wee text field when you hover over a region that gives total impressions. I don't imagine this is difficult and looking into this now.
"