### PR TITLE
hide account menu on greendash if logged in as a pseudouser

### DIFF
--- a/src/js/components/pages/greendash/GreenNavBar.jsx
+++ b/src/js/components/pages/greendash/GreenNavBar.jsx
@@ -72,7 +72,7 @@ const GreenNavBar = ({active}) => {
 
 	// We don't use the standard <Collapse> pattern here because that doesn't support an always-horizontal navbar
 	return (<>
-	<AccountMenu className="float-left" noNav shareWidget={<ShareDash className='m-auto' />}/>
+	{!pseudoUser && <AccountMenu className="float-left" noNav shareWidget={<ShareDash className='m-auto' />}/>}
 	<Navbar dark expand="md" id="green-navbar" className={space('flex-column', 'justify-content-start', isOpen && 'mobile-open')}>
 		<NavbarToggler onClick={toggle} />
 		<Nav navbar vertical>


### PR DESCRIPTION
From a client perspective this looks a little bit off:

![image](https://user-images.githubusercontent.com/93927558/225318746-86711193-d089-4268-8c12-4043c09bb238.png)


This PR will prevent the account menu from showing if you're viewing a dashboard from a shareable link.


