### PR TITLE
temporarily hide journeycard

### DIFF
--- a/src/js/components/pages/greendash/GreenMetrics.jsx
+++ b/src/js/components/pages/greendash/GreenMetrics.jsx
@@ -227,16 +227,17 @@ const GreenMetrics2 = ({}) => {
 				right={{label: 'Per 1000 impressions', value: 'per1000', colour: 'primary'}}
 			/>
 			<Row className="card-row">
-				<Col xs="12" sm="8" className="flex-column">
+				<Col xs="12" sm="12" className="flex-column">
 					<TimeSeriesCard {...commonProps} data={pvChartDatalValue?.by_time.buckets} noData={noData} />
 				</Col>
-				<Col xs="12" sm="4" className="flex-column">
+				{/* TODO: Journeycard temporarily disabled on 27/03. Re-enable before release. */}
+				{/* <Col xs="12" sm="4" className="flex-column">
 					<JourneyCard
 						campaigns={List.hits(pvCampaigns?.value)}
 						{...commonProps}
 						emptyTable={emptyTable || noData}
 					/>
-				</Col>
+				</Col> */}
 			</Row>
 			<Row className="card-row">
 				<Col xs="12" sm="4" className="flex-column">


### PR DESCRIPTION
We're reporting the wrong numbers at the moment - so temporarily removing the journey card until we release later this week.

@wongws11 @laurenwilso FYI