### PR TITLE
An option to include a default list of sites in the Green Recs dashboard WIP

### DIFF
--- a/src/js/components/pages/greendash/GreenRecommendation.tsx
+++ b/src/js/components/pages/greendash/GreenRecommendation.tsx
@@ -309,6 +309,8 @@ const PublisherListRecommendations = (): JSX.Element | null => {
 		setSortedBuckets(bucketsPer1000.slice().sort((a, b) => ((a.co2 as number) - (b.co2 as number))));
 	}, [pvChartTotal?.value]);
 
+	// TODO generic domains design TBC
+	// TODO Do we want to move this into ES and refactor this into emissionscalcTs.ts using DataStore?
 	useEffect(() => {
 		if (!filterUrlParams.generic) return;
 		console.log("Fetching generic domain emissions...");

--- a/src/js/components/pages/greendash/GreenRecommendation.tsx
+++ b/src/js/components/pages/greendash/GreenRecommendation.tsx
@@ -12,9 +12,8 @@ import { GLCard } from '../../impact/GLCards';
 import GreenDashboardFilters from './GreenDashboardFilters';
 import { GreenBuckets, emissionsPerImpressions, getBasefilters, getCarbon, type BaseFilters, type BreakdownRow } from './emissionscalcTs';
 import { Tick } from 'chart.js'
-
-import '../../../../style/GreenRecommendations.less';
 import { CO2e, downloadIcon } from './GreenDashUtils';
+import '../../../../style/GreenRecommendations.less';
 
 const TICKS_NUM = 600;
 
@@ -105,7 +104,7 @@ const RecommendationChart = ({ bucketsPer1000, passBackChart }: { bucketsPer1000
 		let chartOptions: any = {
 			title: 'Volume of publisher impressions by CO₂e emitted per impression',
 			responsive: true,
-			animation: { onComplete: ({chart}) => passBackChart(chart) },
+			animation: { onComplete: ({chart}: {chart: any}) => passBackChart(chart) },
 			// see https://www.chartjs.org/docs/latest/samples/scale-options/titles.html
 			scales: {
 				x: {
@@ -196,7 +195,7 @@ const DomainList = ({ buckets, min, max }: { buckets?: GreenBuckets; min?: numbe
 	useEffect(() => {
 		// Apply high/low CO2 cutoff to publisher list, then sort by name
 		const filteredBuckets = buckets.filter(bkt => (
-			(max ? (bkt.co2 <= max) : (bkt.co2 > min))
+			(max ? (bkt.co2 as number <= max) : (bkt.co2 as number > min!))
 		)).sort((a, b) => a.key > b.key ? 1 : -1);
 		setDomains(filteredBuckets.map(bkt => bkt.key as string));
 		// Calculate how many impressions the filtered publisher list contains
@@ -271,6 +270,7 @@ const PublisherListRecommendations = (): JSX.Element | null => {
 	/* Read / set up filters */
 	interface FitlerUrlParams extends Object {
 		period?: any;
+		generic?: boolean;
 	}
 	const filterUrlParams = getUrlVars(null, null) as FitlerUrlParams;
 	const period = getPeriodFromUrlParams(filterUrlParams);
@@ -297,14 +297,31 @@ const PublisherListRecommendations = (): JSX.Element | null => {
 		getCarbon({ ...baseFilterConfirmed, breakdown: ['domain{"countco2":"sum"}'] })
 	) : null; // - but not until base filters are ready
 
+	console.log('filterUrlParams.generic', filterUrlParams.generic, filterUrlParams);
+
 	// Sort publisher buckets low -> high CO2
 	useEffect(() => {
+		if (filterUrlParams.generic) return;
 		if (!baseFilterConfirmed || !pvChartTotal?.resolved) return;
 		const useSampling = baseFilterConfirmed.prob && baseFilterConfirmed.prob != 0;
 		const pvChartTotalValue = useSampling ? pvChartTotal.value?.sampling : pvChartTotal.value;
 		const bucketsPer1000 = emissionsPerImpressions(pvChartTotalValue.by_domain.buckets);
 		setSortedBuckets(bucketsPer1000.slice().sort((a, b) => ((a.co2 as number) - (b.co2 as number))));
 	}, [pvChartTotal?.value]);
+
+	useEffect(() => {
+		if (!filterUrlParams.generic) return;
+		console.log("Fetching generic domain emissions...");
+		fetch("../js-data/generic-domain-emissions.json")
+			.then((response) => response.json())
+			.then((data) => {
+				const jsonData = data as GreenBuckets;
+				setSortedBuckets(jsonData.slice().sort((a, b) => ((a.co2 as number) - (b.co2 as number))));
+			})
+			.catch((error) => {
+				console.error("Error:", error);
+			});
+	}, []);
 
 	// Calculate CO2 reduction effect of chosen CO2 cutoff
 	useEffect(() => {

--- a/web/js-data/generic-domain-emissions.json
+++ b/web/js-data/generic-domain-emissions.json
@@ -1,0 +1,10647 @@
+[
+    {
+        "key": "unset",
+        "co2": 0.35911347335689503,
+        "count": 309820473.0
+    },
+    {
+        "key": "nine.com.au",
+        "co2": 0.26640912684706064,
+        "count": 11338652.0
+    },
+    {
+        "key": "yahoo.com",
+        "co2": 0.32726360911203034,
+        "count": 9452960.0
+    },
+    {
+        "key": "dailymail.co.uk",
+        "co2": 0.41128585533406575,
+        "count": 25805417.0
+    },
+    {
+        "key": "msn.com",
+        "co2": 1.0683163985358963,
+        "count": 33560028.0
+    },
+    {
+        "key": "news.com.au",
+        "co2": 0.26050124612665554,
+        "count": 15273951.0
+    },
+    {
+        "key": "fandom.com",
+        "co2": 1.1348903688738945,
+        "count": 1723994.0
+    },
+    {
+        "key": "9news.com.au",
+        "co2": 0.26427254864381255,
+        "count": 6846817.0
+    },
+    {
+        "key": "sosialnytt.com",
+        "co2": 0.3128579954516343,
+        "count": 137767.0
+    },
+    {
+        "key": "7news.com.au",
+        "co2": 0.2707482843735583,
+        "count": 1648860.0
+    },
+    {
+        "key": "theguardian.com",
+        "co2": 0.25925944436233944,
+        "count": 2992566.0
+    },
+    {
+        "key": "live.com",
+        "co2": 0.29801676979612896,
+        "count": 10201864.0
+    },
+    {
+        "key": "recipetineats.com",
+        "co2": 0.28211191192479496,
+        "count": 3689737.0
+    },
+    {
+        "key": "gumtree.com.au",
+        "co2": 0.32255951599757277,
+        "count": 8712846.0
+    },
+    {
+        "key": "hotcopper.com.au",
+        "co2": 0.5813257079406908,
+        "count": 1645369.0
+    },
+    {
+        "key": "britannica.com",
+        "co2": 0.6346621119043526,
+        "count": 1372146.0
+    },
+    {
+        "key": "merriam-webster.com",
+        "co2": 0.5224424821422549,
+        "count": 1838142.0
+    },
+    {
+        "key": "thesun.co.uk",
+        "co2": 0.6501409790215268,
+        "count": 1701832.0
+    },
+    {
+        "key": "skynews.com.au",
+        "co2": 0.250217141024811,
+        "count": 803417.0
+    },
+    {
+        "key": "buzzfeed.com",
+        "co2": 0.39556253758062987,
+        "count": 2508598.0
+    },
+    {
+        "key": "citethisforme.com",
+        "co2": 0.2839001035739557,
+        "count": 1654705.0
+    },
+    {
+        "key": "willyweather.com.au",
+        "co2": 0.6123658285075304,
+        "count": 659565.0
+    },
+    {
+        "key": "dailymotion.com",
+        "co2": 1.492658038645342,
+        "count": 1652791.0
+    },
+    {
+        "key": "twitch.tv",
+        "co2": 0.47132238339757127,
+        "count": 367999.0
+    },
+    {
+        "key": "ozbargain.com.au",
+        "co2": 0.5796012359301705,
+        "count": 1299891.0
+    },
+    {
+        "key": "queer.de",
+        "co2": 1.7354655102725316,
+        "count": 255011.0
+    },
+    {
+        "key": "smh.com.au",
+        "co2": 0.2619462672763135,
+        "count": 1687618.0
+    },
+    {
+        "key": "sbs.com.au",
+        "co2": 0.4651388651499771,
+        "count": 1016594.0
+    },
+    {
+        "key": "boredpanda.com",
+        "co2": 0.9387921570457856,
+        "count": 2340474.0
+    },
+    {
+        "key": "espncricinfo.com",
+        "co2": 0.35138985228320857,
+        "count": 1265858.0
+    },
+    {
+        "key": "investing.com",
+        "co2": 0.7353508218831792,
+        "count": 3403360.0
+    },
+    {
+        "key": "perthnow.com.au",
+        "co2": 0.2554758884161667,
+        "count": 583488.0
+    },
+    {
+        "key": "9now.com.au",
+        "co2": 0.5098601860394328,
+        "count": 1640804.0
+    },
+    {
+        "key": "microsoftcasualgames.com",
+        "co2": 0.35987741843643634,
+        "count": 12444354.0
+    },
+    {
+        "key": "10play.com.au",
+        "co2": 0.5095096324509918,
+        "count": 876381.0
+    },
+    {
+        "key": "theage.com.au",
+        "co2": 0.24166557152397275,
+        "count": 1261818.0
+    },
+    {
+        "key": "huffpost.com",
+        "co2": 1.5550034128473804,
+        "count": 475722.0
+    },
+    {
+        "key": "people.com",
+        "co2": 0.27509590488902663,
+        "count": 320971.0
+    },
+    {
+        "key": "drive.com.au",
+        "co2": 0.2361036078459094,
+        "count": 1134201.0
+    },
+    {
+        "key": "espn.com.au",
+        "co2": 0.39241094852608005,
+        "count": 324592.0
+    },
+    {
+        "key": "yourdictionary.com",
+        "co2": 0.6453504457899966,
+        "count": 987432.0
+    },
+    {
+        "key": "ebay.com.au",
+        "co2": 0.23726452873238563,
+        "count": 1232598.0
+    },
+    {
+        "key": "diply.com",
+        "co2": 0.3247008925455086,
+        "count": 639801.0
+    },
+    {
+        "key": "bakeplaysmile.com",
+        "co2": 0.2850716629277383,
+        "count": 1317854.0
+    },
+    {
+        "key": "healthline.com",
+        "co2": 0.24275684707218842,
+        "count": 599961.0
+    },
+    {
+        "key": "researchgate.net",
+        "co2": 0.33539128334995044,
+        "count": 518741.0
+    },
+    {
+        "key": "stuff.co.nz",
+        "co2": 0.23854232123714547,
+        "count": 1221002.0
+    },
+    {
+        "key": "wordhippo.com",
+        "co2": 0.904423603791465,
+        "count": 510322.0
+    },
+    {
+        "key": "techradar.com",
+        "co2": 0.9253420317202785,
+        "count": 169220.0
+    },
+    {
+        "key": "eldersweather.com.au",
+        "co2": 0.9723215376779609,
+        "count": 680148.0
+    },
+    {
+        "key": "trademe.co.nz",
+        "co2": 0.19139021806387835,
+        "count": 1771050.0
+    },
+    {
+        "key": "weatherzone.com.au",
+        "co2": 0.647300874623495,
+        "count": 959652.0
+    },
+    {
+        "key": "iflscience.com",
+        "co2": 0.575706631098937,
+        "count": 504722.0
+    },
+    {
+        "key": "aljazeera.com",
+        "co2": 0.5936885445047931,
+        "count": 153795.0
+    },
+    {
+        "key": "adsenseformobileapps.com",
+        "co2": 0.2054092097181858,
+        "count": 3500608.0
+    },
+    {
+        "key": "thesaurus.com",
+        "co2": 0.2871608745433084,
+        "count": 554006.0
+    },
+    {
+        "key": "ign.com",
+        "co2": 0.6625906647233453,
+        "count": 160878.0
+    },
+    {
+        "key": "allrecipes.com",
+        "co2": 0.28298924193877145,
+        "count": 314288.0
+    },
+    {
+        "key": "onetag-sys.com",
+        "co2": 0.23398951470094476,
+        "count": 15724.0
+    },
+    {
+        "key": "a-z-animals.com",
+        "co2": 0.35953930977347065,
+        "count": 232665.0
+    },
+    {
+        "key": "washingtonpost.com",
+        "co2": 0.2839964095262752,
+        "count": 271624.0
+    },
+    {
+        "key": "cyclingnews.com",
+        "co2": 0.9079021813013352,
+        "count": 162658.0
+    },
+    {
+        "key": "nzherald.co.nz",
+        "co2": 0.21169957110705478,
+        "count": 677511.0
+    },
+    {
+        "key": "foxsports.com.au",
+        "co2": 0.27884581289700067,
+        "count": 470907.0
+    },
+    {
+        "key": "hometalk.com",
+        "co2": 0.6844476044322563,
+        "count": 1303497.0
+    },
+    {
+        "key": "metaspoon.com",
+        "co2": 0.6334635465942249,
+        "count": 612801.0
+    },
+    {
+        "key": "swimsuit.si.com",
+        "co2": 0.4558971273697201,
+        "count": 131174.0
+    },
+    {
+        "key": "yourtv.com.au",
+        "co2": 0.25242977133322364,
+        "count": 586239.0
+    },
+    {
+        "key": "com.peoplefun.wordcross@android",
+        "co2": 0.23401063517058762,
+        "count": 1059160.0
+    },
+    {
+        "key": "seabreeze.com.au",
+        "co2": 0.3854018135364705,
+        "count": 267475.0
+    },
+    {
+        "key": "futbin.com",
+        "co2": 0.4073084257935869,
+        "count": 409854.0
+    },
+    {
+        "key": "ndtv.com",
+        "co2": 0.5634164721454663,
+        "count": 141550.0
+    },
+    {
+        "key": "crazygames.com",
+        "co2": 0.4220590374798512,
+        "count": 365506.0
+    },
+    {
+        "key": "biblegateway.com",
+        "co2": 0.28601406611907904,
+        "count": 233393.0
+    },
+    {
+        "key": "sportingnews.com",
+        "co2": 0.5583442852853101,
+        "count": 160870.0
+    },
+    {
+        "key": "foxnews.com",
+        "co2": 0.28848116885078917,
+        "count": 249881.0
+    },
+    {
+        "key": "domain.com.au",
+        "co2": 0.2694661778507359,
+        "count": 2964283.0
+    },
+    {
+        "key": "bbcgoodfood.com",
+        "co2": 0.2850039555365475,
+        "count": 216313.0
+    },
+    {
+        "key": "gamespot.com",
+        "co2": 0.5756420739667303,
+        "count": 196679.0
+    },
+    {
+        "key": "crash.net",
+        "co2": 0.35655738852762947,
+        "count": 168531.0
+    },
+    {
+        "key": "slate.com",
+        "co2": 0.27551351240047234,
+        "count": 88925.0
+    },
+    {
+        "key": "wegotthiscovered.com",
+        "co2": 0.541939853985972,
+        "count": 340837.0
+    },
+    {
+        "key": "hellomagazine.com",
+        "co2": 0.8266114761822483,
+        "count": 446940.0
+    },
+    {
+        "key": "cnn.com",
+        "co2": 0.3748220334753229,
+        "count": 176814.0
+    },
+    {
+        "key": "etonline.com",
+        "co2": 0.36858405640512754,
+        "count": 101045.0
+    },
+    {
+        "key": "typing.com",
+        "co2": 1.4273796991194643,
+        "count": 373239.0
+    },
+    {
+        "key": "findagrave.com",
+        "co2": 0.3232185477998964,
+        "count": 263158.0
+    },
+    {
+        "key": "foxtel.com.au",
+        "co2": 0.4725121342483083,
+        "count": 216618.0
+    },
+    {
+        "key": "genius.com",
+        "co2": 0.5780147221032478,
+        "count": 193983.0
+    },
+    {
+        "key": "natashaskitchen.com",
+        "co2": 0.29660932399554824,
+        "count": 282798.0
+    },
+    {
+        "key": "sportskeeda.com",
+        "co2": 1.0611549787548968,
+        "count": 522577.0
+    },
+    {
+        "key": "thewest.com.au",
+        "co2": 0.2478622975069433,
+        "count": 96859.0
+    },
+    {
+        "key": "com.dailymail.online@android",
+        "co2": 0.23696362384557107,
+        "count": 243931.0
+    },
+    {
+        "key": "independent.co.uk",
+        "co2": 0.640415675184165,
+        "count": 212203.0
+    },
+    {
+        "key": "bulbagarden.net",
+        "co2": 0.29289430470096256,
+        "count": 250734.0
+    },
+    {
+        "key": "dailydot.com",
+        "co2": 0.5587201326334713,
+        "count": 548722.0
+    },
+    {
+        "key": "sportbible.com",
+        "co2": 0.7906457492601777,
+        "count": 196851.0
+    },
+    {
+        "key": "mirror.co.uk",
+        "co2": 0.972071884346618,
+        "count": 89748.0
+    },
+    {
+        "key": "com.ebay.gumtree.au@android",
+        "co2": 0.22994736069113428,
+        "count": 576480.0
+    },
+    {
+        "key": "bbc.com",
+        "co2": 0.24544379203956573,
+        "count": 680268.0
+    },
+    {
+        "key": "instyle.com",
+        "co2": 0.2707575362713928,
+        "count": 168855.0
+    },
+    {
+        "key": "indianexpress.com",
+        "co2": 1.1956496865209816,
+        "count": 272051.0
+    },
+    {
+        "key": "www.op.gg",
+        "co2": 0.5231485886887999,
+        "count": 396151.0
+    },
+    {
+        "key": "cbssports.com",
+        "co2": 0.35239665960143585,
+        "count": 85917.0
+    },
+    {
+        "key": "watoday.com.au",
+        "co2": 0.25542777250239734,
+        "count": 128420.0
+    },
+    {
+        "key": "espn.com",
+        "co2": 0.39646906806352544,
+        "count": 131376.0
+    },
+    {
+        "key": "cafedelites.com",
+        "co2": 0.29476477517047983,
+        "count": 359416.0
+    },
+    {
+        "key": "kidspot.com.au",
+        "co2": 0.2445557515950679,
+        "count": 24153.0
+    },
+    {
+        "key": "com.lulo.scrabble.classicwords@android",
+        "co2": 0.23042033169617027,
+        "count": 93242.0
+    },
+    {
+        "key": "sporcle.com",
+        "co2": 0.6043684169046991,
+        "count": 267268.0
+    },
+    {
+        "key": "liverpoolecho.co.uk",
+        "co2": 0.8122286182949103,
+        "count": 140654.0
+    },
+    {
+        "key": "allkpop.com",
+        "co2": 0.36448143481902046,
+        "count": 192377.0
+    },
+    {
+        "key": "ladbible.com",
+        "co2": 0.8183929393499556,
+        "count": 277717.0
+    },
+    {
+        "key": "tubitv.com",
+        "co2": 0.47658684584427663,
+        "count": 247801.0
+    },
+    {
+        "key": "spanishdict.com",
+        "co2": 0.7428465758255454,
+        "count": 81957.0
+    },
+    {
+        "key": "petrescue.com.au",
+        "co2": 0.400383095482793,
+        "count": 364122.0
+    },
+    {
+        "key": "com.easybrain.sudoku.android@android",
+        "co2": 0.238325758822798,
+        "count": 235445.0
+    },
+    {
+        "key": "in.playsimple.wordtrip@android",
+        "co2": 0.2471242054355113,
+        "count": 119275.0
+    },
+    {
+        "key": "sen.com.au",
+        "co2": 0.32315821402176953,
+        "count": 153543.0
+    },
+    {
+        "key": "bigfooty.com",
+        "co2": 0.235295098031611,
+        "count": 210679.0
+    },
+    {
+        "key": "clutchpoints.com",
+        "co2": 0.38596747891814903,
+        "count": 83375.0
+    },
+    {
+        "key": "usatoday.com",
+        "co2": 0.2894725030156868,
+        "count": 187950.0
+    },
+    {
+        "key": "gimmesomeoven.com",
+        "co2": 0.321475334353813,
+        "count": 118361.0
+    },
+    {
+        "key": "mail.com",
+        "co2": 0.4974690490885163,
+        "count": 140992.0
+    },
+    {
+        "key": "manchestereveningnews.co.uk",
+        "co2": 0.7492849569832662,
+        "count": 139723.0
+    },
+    {
+        "key": "nexusmods.com",
+        "co2": 1.1192017500158817,
+        "count": 212738.0
+    },
+    {
+        "key": "digitaltrends.com",
+        "co2": 0.7821056395846528,
+        "count": 265887.0
+    },
+    {
+        "key": "kik.android@android",
+        "co2": 0.23522968279308362,
+        "count": 406164.0
+    },
+    {
+        "key": "cookieandkate.com",
+        "co2": 0.2802240216802421,
+        "count": 259511.0
+    },
+    {
+        "key": "ezgif.com",
+        "co2": 0.4040416064513604,
+        "count": 71513.0
+    },
+    {
+        "key": "dotesports.com",
+        "co2": 0.32498352880010767,
+        "count": 706785.0
+    },
+    {
+        "key": "newsweek.com",
+        "co2": 0.34794982046045836,
+        "count": 192918.0
+    },
+    {
+        "key": "timesofindia.com",
+        "co2": 1.1178482031696673,
+        "count": 176420.0
+    },
+    {
+        "key": "jetpunk.com",
+        "co2": 0.3719353110903697,
+        "count": 108413.0
+    },
+    {
+        "key": "webmd.com",
+        "co2": 0.45674579454788783,
+        "count": 344235.0
+    },
+    {
+        "key": "didyouknowfacts.com",
+        "co2": 0.45224350682653386,
+        "count": 162955.0
+    },
+    {
+        "key": "wp.wattpad@android",
+        "co2": 0.23248682638059387,
+        "count": 302213.0
+    },
+    {
+        "key": "ew.com",
+        "co2": 0.2816402820495622,
+        "count": 108272.0
+    },
+    {
+        "key": "weather.com",
+        "co2": 0.2513068687525379,
+        "count": 362673.0
+    },
+    {
+        "key": "oursteps.com.au",
+        "co2": 0.396506605798992,
+        "count": 25905.0
+    },
+    {
+        "key": "quizlet.com",
+        "co2": 0.3400949858970249,
+        "count": 401791.0
+    },
+    {
+        "key": "dictionary.com",
+        "co2": 0.35635163817200627,
+        "count": 148306.0
+    },
+    {
+        "key": "football.london",
+        "co2": 0.851720343504089,
+        "count": 131436.0
+    },
+    {
+        "key": "au.com.weatherzone.android.weatherzonefreeapp@android",
+        "co2": 0.23349245873119887,
+        "count": 637261.0
+    },
+    {
+        "key": "usmagazine.com",
+        "co2": 0.33658263296719,
+        "count": 141910.0
+    },
+    {
+        "key": "comicbook.com",
+        "co2": 0.3529539921427373,
+        "count": 144240.0
+    },
+    {
+        "key": "thebigmansworld.com",
+        "co2": 0.28724209839317494,
+        "count": 128696.0
+    },
+    {
+        "key": "azlyrics.com",
+        "co2": 0.6025865965176743,
+        "count": 107309.0
+    },
+    {
+        "key": "space.com",
+        "co2": 0.9030232367592118,
+        "count": 131875.0
+    },
+    {
+        "key": "aol.com",
+        "co2": 0.32689045914133724,
+        "count": 79390.0
+    },
+    {
+        "key": "forbes.com",
+        "co2": 0.26570906509245185,
+        "count": 283238.0
+    },
+    {
+        "key": "leagueunlimited.com",
+        "co2": 0.2730094096527312,
+        "count": 994821.0
+    },
+    {
+        "key": "momjunction.com",
+        "co2": 0.3932421150971639,
+        "count": 36833.0
+    },
+    {
+        "key": "com.wordgame.words.connect@android",
+        "co2": 0.23999268005485502,
+        "count": 134942.0
+    },
+    {
+        "key": "rapidtables.com",
+        "co2": 0.7275647048709628,
+        "count": 71225.0
+    },
+    {
+        "key": "dexerto.com",
+        "co2": 1.1541499584160704,
+        "count": 274397.0
+    },
+    {
+        "key": "indiatimes.com",
+        "co2": 1.3769553131704877,
+        "count": 143524.0
+    },
+    {
+        "key": "com.zynga.words3@android",
+        "co2": 0.23188808543758715,
+        "count": 255015.0
+    },
+    {
+        "key": "last.fm",
+        "co2": 0.360276814411352,
+        "count": 97824.0
+    },
+    {
+        "key": "deadline.com",
+        "co2": 0.4581407169353225,
+        "count": 87747.0
+    },
+    {
+        "key": "basketball-reference.com",
+        "co2": 0.5645695545507712,
+        "count": 50885.0
+    },
+    {
+        "key": "simplypsychology.org",
+        "co2": 0.8081892192713752,
+        "count": 159708.0
+    },
+    {
+        "key": "businessinsider.com",
+        "co2": 0.3524294402313818,
+        "count": 116257.0
+    },
+    {
+        "key": "thenewdaily.com.au",
+        "co2": 0.29545780098010416,
+        "count": 150222.0
+    },
+    {
+        "key": "w3schools.com",
+        "co2": 0.479516326454963,
+        "count": 310460.0
+    },
+    {
+        "key": "justjared.com",
+        "co2": 0.5842467179284309,
+        "count": 184841.0
+    },
+    {
+        "key": "nypost.com",
+        "co2": 0.3048430634027326,
+        "count": 113191.0
+    },
+    {
+        "key": "com.europosit.pixelcoloring@android",
+        "co2": 0.2365266786961675,
+        "count": 79437.0
+    },
+    {
+        "key": "com.callapp.contacts@android",
+        "co2": 0.23601789876039514,
+        "count": 55993.0
+    },
+    {
+        "key": "com.onelouder.baconreader@android",
+        "co2": 0.2333155188922294,
+        "count": 63936.0
+    },
+    {
+        "key": "nintendolife.com",
+        "co2": 0.3285815143833478,
+        "count": 52784.0
+    },
+    {
+        "key": "australianfrequentflyer.com.au",
+        "co2": 0.33483130935988353,
+        "count": 52773.0
+    },
+    {
+        "key": "womanandhome.com",
+        "co2": 0.9004295911393772,
+        "count": 135426.0
+    },
+    {
+        "key": "swellnet.com",
+        "co2": 0.3236748038771031,
+        "count": 131500.0
+    },
+    {
+        "key": "powerthesaurus.org",
+        "co2": 0.9144178895786803,
+        "count": 97856.0
+    },
+    {
+        "key": "eatingwell.com",
+        "co2": 0.2868331279750324,
+        "count": 132160.0
+    },
+    {
+        "key": "seedtag.com",
+        "co2": 0.26279934891182294,
+        "count": 127133.0
+    },
+    {
+        "key": "fortnitetracker.com",
+        "co2": 0.8361041857518204,
+        "count": 146197.0
+    },
+    {
+        "key": "sohu.com",
+        "co2": 0.6138235299639194,
+        "count": 8214.0
+    },
+    {
+        "key": "variety.com",
+        "co2": 0.46470303351779346,
+        "count": 119071.0
+    },
+    {
+        "key": "com.imgur.mobile@android",
+        "co2": 0.24344864386154494,
+        "count": 252081.0
+    },
+    {
+        "key": "furaffinity.net",
+        "co2": 0.6221951726560006,
+        "count": 58824.0
+    },
+    {
+        "key": "whosampled.com",
+        "co2": 0.40525478991314634,
+        "count": 56434.0
+    },
+    {
+        "key": "www.si.com",
+        "co2": 0.46193883082313925,
+        "count": 53306.0
+    },
+    {
+        "key": "famousbirthdays.com",
+        "co2": 0.26400114268565256,
+        "count": 60291.0
+    },
+    {
+        "key": "manithan.com",
+        "co2": 2.131117942301619,
+        "count": 21020.0
+    },
+    {
+        "key": "7plus.com.au",
+        "co2": 0.4814324627468956,
+        "count": 129796.0
+    },
+    {
+        "key": "factinate.com",
+        "co2": 1.249579796292725,
+        "count": 158907.0
+    },
+    {
+        "key": "bedtimez.com",
+        "co2": 0.4128693968457158,
+        "count": 375696.0
+    },
+    {
+        "key": "brisbanetimes.com.au",
+        "co2": 0.25575374026485337,
+        "count": 122010.0
+    },
+    {
+        "key": "calculatorsoup.com",
+        "co2": 0.32068347038739736,
+        "count": 274486.0
+    },
+    {
+        "key": "sparknotes.com",
+        "co2": 0.5545922173193688,
+        "count": 105978.0
+    },
+    {
+        "key": "com.thechive@android",
+        "co2": 0.23743134280868938,
+        "count": 25805.0
+    },
+    {
+        "key": "thespruceeats.com",
+        "co2": 0.28757661892162745,
+        "count": 95417.0
+    },
+    {
+        "key": "simplyrecipes.com",
+        "co2": 0.2800638446472359,
+        "count": 97110.0
+    },
+    {
+        "key": "thewoksoflife.com",
+        "co2": 0.28708661229481286,
+        "count": 162432.0
+    },
+    {
+        "key": "collinsdictionary.com",
+        "co2": 0.35313686557099905,
+        "count": 130428.0
+    },
+    {
+        "key": "harpersbazaar.com",
+        "co2": 0.29142310520420384,
+        "count": 38281.0
+    },
+    {
+        "key": "flatmates.com.au",
+        "co2": 0.25912249354640843,
+        "count": 140753.0
+    },
+    {
+        "key": "gamesradar.com",
+        "co2": 0.9469932981051189,
+        "count": 172246.0
+    },
+    {
+        "key": "drivingtests.co.nz",
+        "co2": 0.2580230331711374,
+        "count": 112595.0
+    },
+    {
+        "key": "worldpopulationreview.com",
+        "co2": 0.5677364615885685,
+        "count": 72192.0
+    },
+    {
+        "key": "planetf1.com",
+        "co2": 0.444935528777242,
+        "count": 104051.0
+    },
+    {
+        "key": "yourlifechoices.com.au",
+        "co2": 0.46520211197696737,
+        "count": 53132.0
+    },
+    {
+        "key": "sciencealert.com",
+        "co2": 0.46180931852399176,
+        "count": 118318.0
+    },
+    {
+        "key": "cookingclassy.com",
+        "co2": 0.3119327888116577,
+        "count": 74475.0
+    },
+    {
+        "key": "sfgate.com",
+        "co2": 0.3130447913676285,
+        "count": 114892.0
+    },
+    {
+        "key": "realestateview.com.au",
+        "co2": 0.7461470234365621,
+        "count": 228540.0
+    },
+    {
+        "key": "teamtalk.com",
+        "co2": 0.44525046867336093,
+        "count": 73082.0
+    },
+    {
+        "key": "typingclub.com",
+        "co2": 0.7423801606922203,
+        "count": 212112.0
+    },
+    {
+        "key": "nbadraft.net",
+        "co2": 0.2606140263608059,
+        "count": 11826.0
+    },
+    {
+        "key": "cinemablend.com",
+        "co2": 0.924370423617166,
+        "count": 114582.0
+    },
+    {
+        "key": "com.pixel.art.coloring.color.number@android",
+        "co2": 0.23532041334768,
+        "count": 182118.0
+    },
+    {
+        "key": "homemade-gifts-made-easy.com",
+        "co2": 0.27889797850831616,
+        "count": 191349.0
+    },
+    {
+        "key": "mamamia.com.au",
+        "co2": 0.29481692838121454,
+        "count": 25098.0
+    },
+    {
+        "key": "com.ninegag.android.app@android",
+        "co2": 0.2289422767419746,
+        "count": 128129.0
+    },
+    {
+        "key": "tvnz.co.nz",
+        "co2": 0.26258627081153846,
+        "count": 75139.0
+    },
+    {
+        "key": "rent.com.au",
+        "co2": 0.36548399648432295,
+        "count": 167723.0
+    },
+    {
+        "key": "thewordfinder.com",
+        "co2": 0.5438788166781067,
+        "count": 124032.0
+    },
+    {
+        "key": "flightradar24.com",
+        "co2": 0.2926971073086828,
+        "count": 141058.0
+    },
+    {
+        "key": "investopedia.com",
+        "co2": 0.2777133830978939,
+        "count": 48010.0
+    },
+    {
+        "key": "soundcloud-music-audio/id336353151@ios",
+        "co2": 0.2337815977309164,
+        "count": 83143.0
+    },
+    {
+        "key": "cosmopolitan.com",
+        "co2": 0.29054995699341696,
+        "count": 108896.0
+    },
+    {
+        "key": "walesonline.co.uk",
+        "co2": 0.8495089078346545,
+        "count": 79567.0
+    },
+    {
+        "key": "wellplated.com",
+        "co2": 0.2838884829660812,
+        "count": 116925.0
+    },
+    {
+        "key": "wikihow.com",
+        "co2": 0.37124970991603107,
+        "count": 199710.0
+    },
+    {
+        "key": "nowtolove.com.au",
+        "co2": 0.361627647977355,
+        "count": 142898.0
+    },
+    {
+        "key": "brightcove.com",
+        "co2": 0.5202259596281589,
+        "count": 763996.0
+    },
+    {
+        "key": "mumsnet.com",
+        "co2": 0.4738385516486869,
+        "count": 164456.0
+    },
+    {
+        "key": "vogue.com",
+        "co2": 0.38806556658458796,
+        "count": 110175.0
+    },
+    {
+        "key": "au.com.realestate.app@android",
+        "co2": 0.2228863774564779,
+        "count": 168813.0
+    },
+    {
+        "key": "radiopaedia.org",
+        "co2": 0.5464739965414037,
+        "count": 131611.0
+    },
+    {
+        "key": "therighthairstyles.com",
+        "co2": 0.8830301244032625,
+        "count": 88949.0
+    },
+    {
+        "key": "com.zynga.words@android",
+        "co2": 0.2310412363667077,
+        "count": 30980.0
+    },
+    {
+        "key": "tvnz.io",
+        "co2": 0.29297131770407137,
+        "count": 342451.0
+    },
+    {
+        "key": "talksport.com",
+        "co2": 0.6472742907080794,
+        "count": 154456.0
+    },
+    {
+        "key": "nameberry.com",
+        "co2": 0.31880373161573367,
+        "count": 56773.0
+    },
+    {
+        "key": "com.peoplefun.wordchums@android",
+        "co2": 0.24149596434859297,
+        "count": 24635.0
+    },
+    {
+        "key": "gsmarena.com",
+        "co2": 0.8889107061039663,
+        "count": 85975.0
+    },
+    {
+        "key": "justcommodores.com.au",
+        "co2": 0.2620659680850331,
+        "count": 100423.0
+    },
+    {
+        "key": "kitchensanctuary.com",
+        "co2": 0.28839104327776427,
+        "count": 110377.0
+    },
+    {
+        "key": "com.july.cricinfo@android",
+        "co2": 0.23192283743472247,
+        "count": 73683.0
+    },
+    {
+        "key": "zerohanger.com",
+        "co2": 0.39085853075976673,
+        "count": 91357.0
+    },
+    {
+        "key": "androidauthority.com",
+        "co2": 0.5701884399418733,
+        "count": 109433.0
+    },
+    {
+        "key": "freetetris.org",
+        "co2": 0.5778170729486563,
+        "count": 54140.0
+    },
+    {
+        "key": "tasteofhome.com",
+        "co2": 0.518043809167632,
+        "count": 111961.0
+    },
+    {
+        "key": "newidea.com.au",
+        "co2": 0.3658623996667896,
+        "count": 55039.0
+    },
+    {
+        "key": "smithsonianmag.com",
+        "co2": 0.49494577705726545,
+        "count": 33554.0
+    },
+    {
+        "key": "tomsguide.com",
+        "co2": 0.9442396165325905,
+        "count": 86344.0
+    },
+    {
+        "key": "rateyourmusic.com",
+        "co2": 0.31058453866272445,
+        "count": 88585.0
+    },
+    {
+        "key": "jp.pxv.android@android",
+        "co2": 0.22769029865570797,
+        "count": 48401.0
+    },
+    {
+        "key": "skyscanner.com.au",
+        "co2": 0.24154345252507942,
+        "count": 314252.0
+    },
+    {
+        "key": "the-crossword-solver.com",
+        "co2": 0.38086287975527594,
+        "count": 106568.0
+    },
+    {
+        "key": "eonline.com",
+        "co2": 0.2691596990139086,
+        "count": 36758.0
+    },
+    {
+        "key": "biblehub.com",
+        "co2": 0.41201528797349657,
+        "count": 91669.0
+    },
+    {
+        "key": "naturallivingideas.com",
+        "co2": 0.28671421645112144,
+        "count": 73846.0
+    },
+    {
+        "key": "wordplays.com",
+        "co2": 0.6950405542162715,
+        "count": 44370.0
+    },
+    {
+        "key": "icy-veins.com",
+        "co2": 1.2656427625784223,
+        "count": 71761.0
+    },
+    {
+        "key": "productreview.com.au",
+        "co2": 0.2545262231440154,
+        "count": 101247.0
+    },
+    {
+        "key": "scrabble-solver.com",
+        "co2": 0.703015821460535,
+        "count": 74745.0
+    },
+    {
+        "key": "nrl.com",
+        "co2": 0.35853871694619666,
+        "count": 337418.0
+    },
+    {
+        "key": "flightaware.com",
+        "co2": 0.3370769006452695,
+        "count": 131484.0
+    },
+    {
+        "key": "therecipecritic.com",
+        "co2": 0.2824219269811032,
+        "count": 122949.0
+    },
+    {
+        "key": "canberratimes.com.au",
+        "co2": 0.41660684010185767,
+        "count": 51499.0
+    },
+    {
+        "key": "dinnerthendessert.com",
+        "co2": 0.28997610252040956,
+        "count": 97379.0
+    },
+    {
+        "key": "apple.com",
+        "co2": 0.27589065671560975,
+        "count": 7069644.0
+    },
+    {
+        "key": "womansday.com",
+        "co2": 0.2703854283323128,
+        "count": 32399.0
+    },
+    {
+        "key": "verywellfamily.com",
+        "co2": 0.2801079074445505,
+        "count": 36434.0
+    },
+    {
+        "key": "koreaboo.com",
+        "co2": 0.6066498077134074,
+        "count": 131944.0
+    },
+    {
+        "key": "thespruce.com",
+        "co2": 0.2803108354142776,
+        "count": 63812.0
+    },
+    {
+        "key": "com.mobilityware.solitaire@android",
+        "co2": 0.23410957414195774,
+        "count": 51927.0
+    },
+    {
+        "key": "goal.com",
+        "co2": 0.6159107905715492,
+        "count": 52112.0
+    },
+    {
+        "key": "gamehunters.club",
+        "co2": 0.24496009826318568,
+        "count": 50266.0
+    },
+    {
+        "key": "express.co.uk",
+        "co2": 0.9800966095391982,
+        "count": 57775.0
+    },
+    {
+        "key": "hurriyet.com.tr",
+        "co2": 0.9708769746034417,
+        "count": 4681.0
+    },
+    {
+        "key": "www.pep.ph",
+        "co2": 0.9547203070172616,
+        "count": 58450.0
+    },
+    {
+        "key": "au.com.willyweather@android",
+        "co2": 0.2329604264339368,
+        "count": 83556.0
+    },
+    {
+        "key": "bhg.com",
+        "co2": 0.282628448486987,
+        "count": 60792.0
+    },
+    {
+        "key": "looper.com",
+        "co2": 0.3869409828113887,
+        "count": 80281.0
+    },
+    {
+        "key": "com.sofascore.results@android",
+        "co2": 0.23325548070731594,
+        "count": 35493.0
+    },
+    {
+        "key": "blabbermouth.net",
+        "co2": 0.7306389566283229,
+        "count": 74174.0
+    },
+    {
+        "key": "encyclopedia.com",
+        "co2": 0.2918475968158862,
+        "count": 42515.0
+    },
+    {
+        "key": "mobi.ifunny@android",
+        "co2": 0.22862899331552916,
+        "count": 23554.0
+    },
+    {
+        "key": "seriouseats.com",
+        "co2": 0.28069837341029213,
+        "count": 86452.0
+    },
+    {
+        "key": "upworthy.com",
+        "co2": 0.7329182134204483,
+        "count": 45804.0
+    },
+    {
+        "key": "www.rd.com",
+        "co2": 0.5925646299812197,
+        "count": 71929.0
+    },
+    {
+        "key": "thoughtcatalog.com",
+        "co2": 0.3108074947724647,
+        "count": 83649.0
+    },
+    {
+        "key": "minimalistbaker.com",
+        "co2": 0.2839949444393975,
+        "count": 142894.0
+    },
+    {
+        "key": "football365.com",
+        "co2": 0.4432118482568095,
+        "count": 81765.0
+    },
+    {
+        "key": "whatculture.com",
+        "co2": 1.1777661046736796,
+        "count": 89370.0
+    },
+    {
+        "key": "lovingitvegan.com",
+        "co2": 0.29063843246149235,
+        "count": 122042.0
+    },
+    {
+        "key": "9gag.com",
+        "co2": 0.4093924015716712,
+        "count": 44499.0
+    },
+    {
+        "key": "anandabazar.com",
+        "co2": 1.1398292724769759,
+        "count": 55127.0
+    },
+    {
+        "key": "thedailybeast.com",
+        "co2": 0.2780109175937406,
+        "count": 89636.0
+    },
+    {
+        "key": "247solitaire.com",
+        "co2": 0.3165584564899535,
+        "count": 143890.0
+    },
+    {
+        "key": "adsbynimbus.com",
+        "co2": 0.2655111651207808,
+        "count": 231338.0
+    },
+    {
+        "key": "justonecookbook.com",
+        "co2": 0.28868782413819033,
+        "count": 91130.0
+    },
+    {
+        "key": "androidcentral.com",
+        "co2": 0.9190108643983457,
+        "count": 44570.0
+    },
+    {
+        "key": "timeout.com",
+        "co2": 1.1930534432742808,
+        "count": 247631.0
+    },
+    {
+        "key": "celebitchy.com",
+        "co2": 0.302692143455445,
+        "count": 72169.0
+    },
+    {
+        "key": "uk.co.aifactory.backgammonfree@android",
+        "co2": 0.24468975801742718,
+        "count": 26033.0
+    },
+    {
+        "key": "dnitv.com",
+        "co2": 0.46150395929543536,
+        "count": 464631.0
+    },
+    {
+        "key": "scotsman.com",
+        "co2": 1.1744526690473927,
+        "count": 102321.0
+    },
+    {
+        "key": "drugs.com",
+        "co2": 0.30327771728258357,
+        "count": 47243.0
+    },
+    {
+        "key": "game.puzzle.woodypuzzle@android",
+        "co2": 0.2318480277537859,
+        "count": 42119.0
+    },
+    {
+        "key": "sofifa.com",
+        "co2": 0.5353243372207579,
+        "count": 29451.0
+    },
+    {
+        "key": "vegrecipesofindia.com",
+        "co2": 0.3230962426208759,
+        "count": 65864.0
+    },
+    {
+        "key": "milliyet.com.tr",
+        "co2": 0.8997024511633536,
+        "count": 3690.0
+    },
+    {
+        "key": "stayathomemum.com.au",
+        "co2": 0.6255749680317846,
+        "count": 33333.0
+    },
+    {
+        "key": "thedrive.com",
+        "co2": 0.2727137482524572,
+        "count": 58284.0
+    },
+    {
+        "key": "emojipedia.org",
+        "co2": 0.9385169771048258,
+        "count": 88612.0
+    },
+    {
+        "key": "rollingstone.com",
+        "co2": 0.5357693484564443,
+        "count": 34631.0
+    },
+    {
+        "key": "differencebetween.net",
+        "co2": 0.2973082038549023,
+        "count": 73081.0
+    },
+    {
+        "key": "indiatoday.in",
+        "co2": 0.9496772392263733,
+        "count": 25583.0
+    },
+    {
+        "key": "ratemds.com",
+        "co2": 0.6656452064574463,
+        "count": 42783.0
+    },
+    {
+        "key": "interest.co.nz",
+        "co2": 0.5820199978447155,
+        "count": 78808.0
+    },
+    {
+        "key": "thehill.com",
+        "co2": 0.27659990544362867,
+        "count": 55570.0
+    },
+    {
+        "key": "birminghammail.co.uk",
+        "co2": 0.8884024246209761,
+        "count": 48993.0
+    },
+    {
+        "key": "vogue.com.au",
+        "co2": 0.26939701073001243,
+        "count": 50173.0
+    },
+    {
+        "key": "heavy.com",
+        "co2": 0.513957671829967,
+        "count": 72663.0
+    },
+    {
+        "key": "taste.com.au",
+        "co2": 0.2387721315666414,
+        "count": 48457.0
+    },
+    {
+        "key": "com.icenta.sudoku.ui@android",
+        "co2": 0.23702876138231546,
+        "count": 25193.0
+    },
+    {
+        "key": "pethelpful.com",
+        "co2": 0.49489752461198344,
+        "count": 77403.0
+    },
+    {
+        "key": "math-aids.com",
+        "co2": 0.5311917280566193,
+        "count": 42277.0
+    },
+    {
+        "key": "bobvila.com",
+        "co2": 0.2741713024397895,
+        "count": 39697.0
+    },
+    {
+        "key": "com.mt.mtxx.mtxx@android",
+        "co2": 0.2383975860807185,
+        "count": 15876.0
+    },
+    {
+        "key": "horizontimes.com",
+        "co2": 0.3989548014588995,
+        "count": 227093.0
+    },
+    {
+        "key": "daringgourmet.com",
+        "co2": 0.2853904102830037,
+        "count": 73561.0
+    },
+    {
+        "key": "zerotackle.com",
+        "co2": 0.46354914080613535,
+        "count": 210753.0
+    },
+    {
+        "key": "golf.com",
+        "co2": 0.2962040710907305,
+        "count": 36516.0
+    },
+    {
+        "key": "windowscentral.com",
+        "co2": 0.9225761428869893,
+        "count": 58761.0
+    },
+    {
+        "key": "metacritic.com",
+        "co2": 0.5805797916784988,
+        "count": 56456.0
+    },
+    {
+        "key": "cnnturk.com",
+        "co2": 1.2891997426192214,
+        "count": 2078.0
+    },
+    {
+        "key": "thestayathomechef.com",
+        "co2": 0.29247066225324214,
+        "count": 95712.0
+    },
+    {
+        "key": "cleverst.com",
+        "co2": 0.7339308441905659,
+        "count": 24654.0
+    },
+    {
+        "key": "de.motain.iliga@android",
+        "co2": 0.2284248218497569,
+        "count": 35246.0
+    },
+    {
+        "key": "thechunkychef.com",
+        "co2": 0.29100886701562606,
+        "count": 91782.0
+    },
+    {
+        "key": "wordreference.com",
+        "co2": 0.37370902794876576,
+        "count": 54866.0
+    },
+    {
+        "key": "wordunscrambler.net",
+        "co2": 0.7748756447500581,
+        "count": 61268.0
+    },
+    {
+        "key": "example.com",
+        "co2": 0.26099606548527055,
+        "count": 33691.0
+    },
+    {
+        "key": "com.opera.mini.native@android",
+        "co2": 0.24171754618408134,
+        "count": 6142.0
+    },
+    {
+        "key": "spendwithpennies.com",
+        "co2": 0.28716654752607557,
+        "count": 96094.0
+    },
+    {
+        "key": "kotaku.com",
+        "co2": 0.28805028912912145,
+        "count": 31862.0
+    },
+    {
+        "key": "teenvogue.com",
+        "co2": 0.37310715685875606,
+        "count": 56749.0
+    },
+    {
+        "key": "dawn.com",
+        "co2": 0.48094830549072004,
+        "count": 12670.0
+    },
+    {
+        "key": "motorsport.com",
+        "co2": 0.7380827683678238,
+        "count": 58139.0
+    },
+    {
+        "key": "thecalculatorsite.com",
+        "co2": 1.4241414040851308,
+        "count": 35282.0
+    },
+    {
+        "key": "billboard.com",
+        "co2": 0.44950419817684517,
+        "count": 35425.0
+    },
+    {
+        "key": "com.lemongame.freecell.solitaire@android",
+        "co2": 0.23375114420003879,
+        "count": 20909.0
+    },
+    {
+        "key": "fourfourtwo.com",
+        "co2": 0.9074537812187774,
+        "count": 35527.0
+    },
+    {
+        "key": "ogyfmts.com",
+        "co2": 0.4781260633421143,
+        "count": 33042.0
+    },
+    {
+        "key": "babycenter.com",
+        "co2": 0.29770323365840273,
+        "count": 36505.0
+    },
+    {
+        "key": "worldatlas.com",
+        "co2": 0.4918798671961752,
+        "count": 17392.0
+    },
+    {
+        "key": "tribuneindia.com",
+        "co2": 0.5510625067279044,
+        "count": 21786.0
+    },
+    {
+        "key": "momontimeout.com",
+        "co2": 0.283308100438082,
+        "count": 81521.0
+    },
+    {
+        "key": "urbandictionary.com",
+        "co2": 0.31986792769922845,
+        "count": 3952.0
+    },
+    {
+        "key": "articlesvally.com",
+        "co2": 0.7670361205081131,
+        "count": 52353.0
+    },
+    {
+        "key": "chroniclelive.co.uk",
+        "co2": 0.9350403658317155,
+        "count": 59607.0
+    },
+    {
+        "key": "com.soundcloud.android@android",
+        "co2": 0.23392659778449204,
+        "count": 23904.0
+    },
+    {
+        "key": "football-italia.net",
+        "co2": 0.7236372455011809,
+        "count": 21032.0
+    },
+    {
+        "key": "arstechnica.com",
+        "co2": 0.26874911816152824,
+        "count": 42627.0
+    },
+    {
+        "key": "interestingengineering.com",
+        "co2": 0.48960620842806146,
+        "count": 117910.0
+    },
+    {
+        "key": "simply-delicious-food.com",
+        "co2": 0.2899567148096932,
+        "count": 56098.0
+    },
+    {
+        "key": "hindustantimes.com",
+        "co2": 0.5547715115781439,
+        "count": 7203.0
+    },
+    {
+        "key": "gamebanana.com",
+        "co2": 1.190166076405228,
+        "count": 31909.0
+    },
+    {
+        "key": "tastesbetterfromscratch.com",
+        "co2": 0.28640327831153906,
+        "count": 58872.0
+    },
+    {
+        "key": "imore.com",
+        "co2": 0.9182192583970635,
+        "count": 35830.0
+    },
+    {
+        "key": "theperspective.com",
+        "co2": 0.4594990417882538,
+        "count": 17741.0
+    },
+    {
+        "key": "uk.co.aifactory.euchrefree@android",
+        "co2": 0.2438252415366992,
+        "count": 12590.0
+    },
+    {
+        "key": "wordsolver.net",
+        "co2": 0.3538034802308424,
+        "count": 43961.0
+    },
+    {
+        "key": "oversixty.com.au",
+        "co2": 0.5601147112100343,
+        "count": 81645.0
+    },
+    {
+        "key": "allhomes.com.au",
+        "co2": 0.26069945769836533,
+        "count": 64055.0
+    },
+    {
+        "key": "hoopshype.com",
+        "co2": 0.3749179166854308,
+        "count": 25897.0
+    },
+    {
+        "key": "com.resultadosfutbol.mobile@android",
+        "co2": 0.25997512042061455,
+        "count": 106161.0
+    },
+    {
+        "key": "definition.org",
+        "co2": 0.6070639447974688,
+        "count": 72962.0
+    },
+    {
+        "key": "com.cricbuzz.android@android",
+        "co2": 0.22962883419670524,
+        "count": 100727.0
+    },
+    {
+        "key": "pcgamer.com",
+        "co2": 0.9057912088537502,
+        "count": 17816.0
+    },
+    {
+        "key": "au.com.elders.android.weather@android",
+        "co2": 0.2405537854419745,
+        "count": 19279.0
+    },
+    {
+        "key": "wrestlingnews.co",
+        "co2": 0.40015917499857334,
+        "count": 32695.0
+    },
+    {
+        "key": "newshub.co.nz",
+        "co2": 0.19551356170543527,
+        "count": 49261.0
+    },
+    {
+        "key": "ukutabs.com",
+        "co2": 0.6171314405974324,
+        "count": 31292.0
+    },
+    {
+        "key": "com.myfitnesspal.android@android",
+        "co2": 0.23165818355036333,
+        "count": 111276.0
+    },
+    {
+        "key": "com.taggedapp@android",
+        "co2": 0.23054890377901208,
+        "count": 62049.0
+    },
+    {
+        "key": "engadget.com",
+        "co2": 0.30831955847942055,
+        "count": 24496.0
+    },
+    {
+        "key": "myfussyeater.com",
+        "co2": 0.2750030963809039,
+        "count": 77706.0
+    },
+    {
+        "key": "goodhousekeeping.com",
+        "co2": 0.3062775976681841,
+        "count": 69553.0
+    },
+    {
+        "key": "manualslib.com",
+        "co2": 0.6451632872242941,
+        "count": 29707.0
+    },
+    {
+        "key": "novelupdates.com",
+        "co2": 0.597016340227915,
+        "count": 107857.0
+    },
+    {
+        "key": "com.l@android",
+        "co2": 0.24499304609118935,
+        "count": 18281.0
+    },
+    {
+        "key": "reuters.com",
+        "co2": 0.2983012877003881,
+        "count": 24176.0
+    },
+    {
+        "key": "thenarcissisticlife.com",
+        "co2": 0.2893359936761183,
+        "count": 80502.0
+    },
+    {
+        "key": "nytimes.com",
+        "co2": 0.25650288203364985,
+        "count": 14760.0
+    },
+    {
+        "key": "theringer.com",
+        "co2": 0.2834949826159007,
+        "count": 29098.0
+    },
+    {
+        "key": "mobilityware.com",
+        "co2": 0.3422188665475297,
+        "count": 49931.0
+    },
+    {
+        "key": "thestreet.com",
+        "co2": 0.5713555980435846,
+        "count": 35060.0
+    },
+    {
+        "key": "addictinggames.com",
+        "co2": 0.24963459564588086,
+        "count": 57431.0
+    },
+    {
+        "key": "com.mobilityware.freecell@android",
+        "co2": 0.23175735752030038,
+        "count": 19993.0
+    },
+    {
+        "key": "cbsnews.com",
+        "co2": 0.37808220072199905,
+        "count": 44175.0
+    },
+    {
+        "key": "nbcnews.com",
+        "co2": 0.26713089063084083,
+        "count": 10435.0
+    },
+    {
+        "key": "udn.com",
+        "co2": 0.6069383115214032,
+        "count": 21590.0
+    },
+    {
+        "key": "apost.com",
+        "co2": 0.8978474175179908,
+        "count": 14254.0
+    },
+    {
+        "key": "delish.com",
+        "co2": 0.2772508375408341,
+        "count": 89180.0
+    },
+    {
+        "key": "glamour.com",
+        "co2": 0.4335860815019785,
+        "count": 61330.0
+    },
+    {
+        "key": "gta5-mods.com",
+        "co2": 0.25141072998077263,
+        "count": 57089.0
+    },
+    {
+        "key": "indianhealthyrecipes.com",
+        "co2": 0.5295584227468436,
+        "count": 74660.0
+    },
+    {
+        "key": "timeanddate.com",
+        "co2": 0.4646998738484964,
+        "count": 63887.0
+    },
+    {
+        "key": "homedit.com",
+        "co2": 0.2873356367446681,
+        "count": 73228.0
+    },
+    {
+        "key": "thecrazytourist.com",
+        "co2": 0.30310124356674967,
+        "count": 123243.0
+    },
+    {
+        "key": "com.bigduckgames.flow@android",
+        "co2": 0.23211078019507528,
+        "count": 24567.0
+    },
+    {
+        "key": "pinkvilla.com",
+        "co2": 0.5867847790438886,
+        "count": 53255.0
+    },
+    {
+        "key": "whowhatwear.com",
+        "co2": 0.9677249396969616,
+        "count": 79513.0
+    },
+    {
+        "key": "d20pfsrd.com",
+        "co2": 0.28602914732068396,
+        "count": 37872.0
+    },
+    {
+        "key": "usnews.com",
+        "co2": 0.28070636627063894,
+        "count": 92274.0
+    },
+    {
+        "key": "everydayhealth.com",
+        "co2": 0.32356873314747087,
+        "count": 21366.0
+    },
+    {
+        "key": "littlebinsforlittlehands.com",
+        "co2": 0.29338765544362616,
+        "count": 43741.0
+    },
+    {
+        "key": "marieclaire.com",
+        "co2": 0.9388500320769777,
+        "count": 80138.0
+    },
+    {
+        "key": "perezhilton.com",
+        "co2": 0.5038882887150979,
+        "count": 30462.0
+    },
+    {
+        "key": "twentytwowords.com",
+        "co2": 0.46079702665361405,
+        "count": 58385.0
+    },
+    {
+        "key": "theverge.com",
+        "co2": 0.2853191100983269,
+        "count": 43785.0
+    },
+    {
+        "key": "nbcsports.com",
+        "co2": 0.29683805200228774,
+        "count": 16481.0
+    },
+    {
+        "key": "english.premier.live@android",
+        "co2": 0.2293114641492005,
+        "count": 41866.0
+    },
+    {
+        "key": "maangchi.com",
+        "co2": 0.2793369219480744,
+        "count": 16822.0
+    },
+    {
+        "key": "eurosport.com",
+        "co2": 1.092014738141102,
+        "count": 13811.0
+    },
+    {
+        "key": "pof.com",
+        "co2": 0.2614395843017932,
+        "count": 52064.0
+    },
+    {
+        "key": "surfline.com",
+        "co2": 0.3980734324641178,
+        "count": 41284.0
+    },
+    {
+        "key": "tides4fishing.com",
+        "co2": 0.3534925580584586,
+        "count": 22424.0
+    },
+    {
+        "key": "uk.co.aifactory.chessfree@android",
+        "co2": 0.24150335555763885,
+        "count": 17368.0
+    },
+    {
+        "key": "brides.com",
+        "co2": 0.28255180053372475,
+        "count": 41810.0
+    },
+    {
+        "key": "com.teamapp.teamapp@android",
+        "co2": 0.22893330844709636,
+        "count": 34267.0
+    },
+    {
+        "key": "neoseeker.com",
+        "co2": 0.30461677091383,
+        "count": 19209.0
+    },
+    {
+        "key": "awxcdn.com",
+        "co2": 0.25756159560950004,
+        "count": 146591.0
+    },
+    {
+        "key": "metro.co.uk",
+        "co2": 0.3824971794733051,
+        "count": 64482.0
+    },
+    {
+        "key": "screenrant.com",
+        "co2": 0.7234922839813389,
+        "count": 50947.0
+    },
+    {
+        "key": "serebii.net",
+        "co2": 0.5469449966640547,
+        "count": 118240.0
+    },
+    {
+        "key": "com.appynation.wbpc@android",
+        "co2": 0.23440725552972247,
+        "count": 20775.0
+    },
+    {
+        "key": "com.happysky.spider@android",
+        "co2": 0.23053674063632904,
+        "count": 7710.0
+    },
+    {
+        "key": "minecraftskins.com",
+        "co2": 0.37231974894694103,
+        "count": 104511.0
+    },
+    {
+        "key": "www.xe.com",
+        "co2": 0.34239977671622324,
+        "count": 210293.0
+    },
+    {
+        "key": "iambaker.net",
+        "co2": 0.28998993247135924,
+        "count": 50228.0
+    },
+    {
+        "key": "jocooks.com",
+        "co2": 0.28610618409959115,
+        "count": 66927.0
+    },
+    {
+        "key": "oneindia.com",
+        "co2": 0.5782845569529327,
+        "count": 431341.0
+    },
+    {
+        "key": "stylecaster.com",
+        "co2": 0.3773177145792141,
+        "count": 55678.0
+    },
+    {
+        "key": "dotabuff.com",
+        "co2": 0.43717109859297615,
+        "count": 60874.0
+    },
+    {
+        "key": "yardbarker.com",
+        "co2": 0.526594463629014,
+        "count": 45397.0
+    },
+    {
+        "key": "aspicyperspective.com",
+        "co2": 0.32256002158636227,
+        "count": 37228.0
+    },
+    {
+        "key": "com.naver.linewebtoon@android",
+        "co2": 0.23284802173421912,
+        "count": 13370.0
+    },
+    {
+        "key": "marinetraffic.com",
+        "co2": 0.32831627114138295,
+        "count": 28203.0
+    },
+    {
+        "key": "andhrajyothy.com",
+        "co2": 0.5803186106122558,
+        "count": 19765.0
+    },
+    {
+        "key": "com.metropcs.metrozone@android",
+        "co2": 0.2409787512369099,
+        "count": 3994.0
+    },
+    {
+        "key": "thehulltruth.com",
+        "co2": 0.46759995603881654,
+        "count": 38411.0
+    },
+    {
+        "key": "destructoid.com",
+        "co2": 0.27917566929148646,
+        "count": 83236.0
+    },
+    {
+        "key": "denofgeek.com",
+        "co2": 0.3383848783895861,
+        "count": 26890.0
+    },
+    {
+        "key": "racefans.net",
+        "co2": 0.4660934104224618,
+        "count": 27931.0
+    },
+    {
+        "key": "news18.com",
+        "co2": 0.2723398310225568,
+        "count": 44511.0
+    },
+    {
+        "key": "newyorker.com",
+        "co2": 0.3897200743816032,
+        "count": 40936.0
+    },
+    {
+        "key": "straitstimes.com",
+        "co2": 0.37145472077722125,
+        "count": 8049.0
+    },
+    {
+        "key": "cnbc.com",
+        "co2": 0.25432191385446506,
+        "count": 3571.0
+    },
+    {
+        "key": "gizmodo.com",
+        "co2": 0.2868994858606346,
+        "count": 21590.0
+    },
+    {
+        "key": "trustedreviews.com",
+        "co2": 0.5892383650687872,
+        "count": 50548.0
+    },
+    {
+        "key": "inspiredtaste.net",
+        "co2": 0.5094227684604318,
+        "count": 41593.0
+    },
+    {
+        "key": "com.freerange360.mpp.GOAL@android",
+        "co2": 0.2333442428803722,
+        "count": 6862.0
+    },
+    {
+        "key": "cricket.com.au",
+        "co2": 0.8224543436623128,
+        "count": 81383.0
+    },
+    {
+        "key": "com.mobilecardgames.solitaire@android",
+        "co2": 0.23728869503001995,
+        "count": 12069.0
+    },
+    {
+        "key": "com.pieyel.scrabble@android",
+        "co2": 0.23323118401759435,
+        "count": 27899.0
+    },
+    {
+        "key": "realestate.com.au",
+        "co2": 0.2523654479900395,
+        "count": 2533810.0
+    },
+    {
+        "key": "thoughtco.com",
+        "co2": 0.2777121793331793,
+        "count": 23921.0
+    },
+    {
+        "key": "droom.sleepIfUCan@android",
+        "co2": 0.23124984626552605,
+        "count": 25160.0
+    },
+    {
+        "key": "fantrax.com",
+        "co2": 0.7126796135446009,
+        "count": 45329.0
+    },
+    {
+        "key": "fortune.com",
+        "co2": 0.26873361862694406,
+        "count": 44666.0
+    },
+    {
+        "key": "parents.com",
+        "co2": 0.2777105389740794,
+        "count": 37479.0
+    },
+    {
+        "key": "pprune.org",
+        "co2": 0.446818059976861,
+        "count": 24292.0
+    },
+    {
+        "key": "se.footballaddicts.livescore@android",
+        "co2": 0.2323134035299277,
+        "count": 7880.0
+    },
+    {
+        "key": "com.online.AndroidManorama@android",
+        "co2": 0.23580638378088506,
+        "count": 9614.0
+    },
+    {
+        "key": "crosswordsolver.org",
+        "co2": 2.0099474369880697,
+        "count": 67737.0
+    },
+    {
+        "key": "freemahjong.org",
+        "co2": 0.6199247750848825,
+        "count": 54386.0
+    },
+    {
+        "key": "byrdie.com",
+        "co2": 0.28023582236201017,
+        "count": 32670.0
+    },
+    {
+        "key": "com.Project100Pi.themusicplayer@android",
+        "co2": 0.2323913318837111,
+        "count": 10343.0
+    },
+    {
+        "key": "fontspace.com",
+        "co2": 0.4483844782980016,
+        "count": 21878.0
+    },
+    {
+        "key": "pastfactory.com",
+        "co2": 0.7185595185658751,
+        "count": 62073.0
+    },
+    {
+        "key": "newscientist.com",
+        "co2": 0.30214564045806863,
+        "count": 26794.0
+    },
+    {
+        "key": "themediatrust.com",
+        "co2": 0.26394479340547095,
+        "count": 28967.0
+    },
+    {
+        "key": "onegoodthingbyjillee.com",
+        "co2": 0.29760276147433734,
+        "count": 48455.0
+    },
+    {
+        "key": "com.mobile.ign@android",
+        "co2": 0.2310422080656023,
+        "count": 7098.0
+    },
+    {
+        "key": "eatingbirdfood.com",
+        "co2": 0.28850093522303105,
+        "count": 44397.0
+    },
+    {
+        "key": "indexww.com",
+        "co2": 0.5179455997012248,
+        "count": 443177.0
+    },
+    {
+        "key": "allthatsinteresting.com",
+        "co2": 0.8558591294959232,
+        "count": 9945.0
+    },
+    {
+        "key": "hitc.com",
+        "co2": 0.5322352993402935,
+        "count": 59092.0
+    },
+    {
+        "key": "kirbiecravings.com",
+        "co2": 0.281943257458847,
+        "count": 54866.0
+    },
+    {
+        "key": "twinfinite.net",
+        "co2": 0.3160274371005379,
+        "count": 184526.0
+    },
+    {
+        "key": "educationworld.com",
+        "co2": 0.5082516257297179,
+        "count": 22216.0
+    },
+    {
+        "key": "pluto.tv",
+        "co2": 1.0671238713944704,
+        "count": 102651.0
+    },
+    {
+        "key": "livemint.com",
+        "co2": 0.7378633233534515,
+        "count": 28232.0
+    },
+    {
+        "key": "eatwell101.com",
+        "co2": 0.29361412513277924,
+        "count": 42144.0
+    },
+    {
+        "key": "ewrestlingnews.com",
+        "co2": 0.8399797530136641,
+        "count": 39668.0
+    },
+    {
+        "key": "mymodernmet.com",
+        "co2": 0.3016638128761078,
+        "count": 70501.0
+    },
+    {
+        "key": "jalopnik.com",
+        "co2": 0.2917420680350496,
+        "count": 14014.0
+    },
+    {
+        "key": "reference.com",
+        "co2": 0.825767738503456,
+        "count": 174615.0
+    },
+    {
+        "key": "standard.co.uk",
+        "co2": 0.9064904397194654,
+        "count": 15422.0
+    },
+    {
+        "key": "www.gq.com",
+        "co2": 0.4077712321515709,
+        "count": 31190.0
+    },
+    {
+        "key": "ebay.co.uk",
+        "co2": 0.3025178914248383,
+        "count": 34054.0
+    },
+    {
+        "key": "illawarramercury.com.au",
+        "co2": 0.41252021072085054,
+        "count": 9057.0
+    },
+    {
+        "key": "namemc.com",
+        "co2": 0.48847600691143234,
+        "count": 49051.0
+    },
+    {
+        "key": "outbrain.com",
+        "co2": 0.7028825579492463,
+        "count": 73756.0
+    },
+    {
+        "key": "telegraph.co.uk",
+        "co2": 0.24850003229496387,
+        "count": 76392.0
+    },
+    {
+        "key": "com.lexulous.Lexulous@android",
+        "co2": 0.24072806488679305,
+        "count": 4696.0
+    },
+    {
+        "key": "googleadservices.com",
+        "co2": 0.24148152881833657,
+        "count": 24984.0
+    },
+    {
+        "key": "leitesculinaria.com",
+        "co2": 0.29524503668411145,
+        "count": 56430.0
+    },
+    {
+        "key": "com.peoplefun.wordflowers@android",
+        "co2": 0.23167998214365,
+        "count": 16104.0
+    },
+    {
+        "key": "verywellfit.com",
+        "co2": 0.2820914733016049,
+        "count": 20760.0
+    },
+    {
+        "key": "mediaite.com",
+        "co2": 0.4440418524452798,
+        "count": 36546.0
+    },
+    {
+        "key": "com.rubenmayayo.reddit@android",
+        "co2": 0.230984564084672,
+        "count": 22062.0
+    },
+    {
+        "key": "guidingtech.com",
+        "co2": 0.3020046588031958,
+        "count": 38842.0
+    },
+    {
+        "key": "com.foxnews.android@android",
+        "co2": 0.23103293753948811,
+        "count": 15439.0
+    },
+    {
+        "key": "dinneratthezoo.com",
+        "co2": 0.285206725101372,
+        "count": 40600.0
+    },
+    {
+        "key": "diffen.com",
+        "co2": 0.29601407138418606,
+        "count": 18296.0
+    },
+    {
+        "key": "gamepressure.com",
+        "co2": 0.7096746057533485,
+        "count": 35446.0
+    },
+    {
+        "key": "tvline.com",
+        "co2": 0.4849108882341313,
+        "count": 21756.0
+    },
+    {
+        "key": "com.fusionmedia.investing@android",
+        "co2": 0.23431983315505703,
+        "count": 15775.0
+    },
+    {
+        "key": "mentalfloss.com",
+        "co2": 0.699902256056867,
+        "count": 36331.0
+    },
+    {
+        "key": "com.ludo.king@android",
+        "co2": 0.23440885857788335,
+        "count": 6278.0
+    },
+    {
+        "key": "lifewire.com",
+        "co2": 0.28317267080668834,
+        "count": 25975.0
+    },
+    {
+        "key": "skysports.com",
+        "co2": 0.5195274505589197,
+        "count": 47606.0
+    },
+    {
+        "key": "spotrac.com",
+        "co2": 0.2922540705859763,
+        "count": 15175.0
+    },
+    {
+        "key": "superbru.com",
+        "co2": 0.3039247440605208,
+        "count": 13015.0
+    },
+    {
+        "key": "com.skout.android@android",
+        "co2": 0.2270487379997384,
+        "count": 36417.0
+    },
+    {
+        "key": "liquor.com",
+        "co2": 0.28443834794878314,
+        "count": 16614.0
+    },
+    {
+        "key": "vanityfair.com",
+        "co2": 0.3890868197760346,
+        "count": 36447.0
+    },
+    {
+        "key": "com.viber.voip@android",
+        "co2": 0.2397250554495977,
+        "count": 23727.0
+    },
+    {
+        "key": "allfreeknitting.com",
+        "co2": 0.7948166121802656,
+        "count": 10105.0
+    },
+    {
+        "key": "driverknowledgetests.com",
+        "co2": 0.2717329111532433,
+        "count": 16818.0
+    },
+    {
+        "key": "behindthevoiceactors.com",
+        "co2": 0.2876183383881597,
+        "count": 31383.0
+    },
+    {
+        "key": "sh.whisper@android",
+        "co2": 0.2285089006928176,
+        "count": 14763.0
+    },
+    {
+        "key": "411mania.com",
+        "co2": 0.3108126564859906,
+        "count": 36363.0
+    },
+    {
+        "key": "com.apalon.myclockfree@android",
+        "co2": 0.22873371000084586,
+        "count": 19966.0
+    },
+    {
+        "key": "aussie.rules.live@android",
+        "co2": 0.2295736033276741,
+        "count": 49443.0
+    },
+    {
+        "key": "mamanatural.com",
+        "co2": 0.28378521240216525,
+        "count": 35915.0
+    },
+    {
+        "key": "startsat60.com",
+        "co2": 0.30426512742320333,
+        "count": 35883.0
+    },
+    {
+        "key": "spin.ph",
+        "co2": 0.6093638509089441,
+        "count": 24272.0
+    },
+    {
+        "key": "mtggoldfish.com",
+        "co2": 0.3271022924755883,
+        "count": 65102.0
+    },
+    {
+        "key": "self.com",
+        "co2": 0.3931363614848882,
+        "count": 38158.0
+    },
+    {
+        "key": "thelist.com",
+        "co2": 0.38073118864966504,
+        "count": 62843.0
+    },
+    {
+        "key": "jwplatform.com",
+        "co2": 0.5125204756737894,
+        "count": 5972.0
+    },
+    {
+        "key": "thedroidguy.com",
+        "co2": 0.29459550252010713,
+        "count": 67611.0
+    },
+    {
+        "key": "theendlessmeal.com",
+        "co2": 0.28660299646153,
+        "count": 33880.0
+    },
+    {
+        "key": "fashionista.com",
+        "co2": 0.5026550280302667,
+        "count": 12100.0
+    },
+    {
+        "key": "fextralife.com",
+        "co2": 0.8326856169675103,
+        "count": 16683.0
+    },
+    {
+        "key": "redbookmag.com",
+        "co2": 0.2715501306298687,
+        "count": 8244.0
+    },
+    {
+        "key": "thestar.com.my",
+        "co2": 1.1175858931601477,
+        "count": 50220.0
+    },
+    {
+        "key": "notebookcheck.net",
+        "co2": 0.8556529734489303,
+        "count": 53685.0
+    },
+    {
+        "key": "howmanysyllables.com",
+        "co2": 0.7735444674974519,
+        "count": 8735.0
+    },
+    {
+        "key": "techcrunch.com",
+        "co2": 0.2903834856584683,
+        "count": 22614.0
+    },
+    {
+        "key": "tennisworldusa.org",
+        "co2": 1.4590303733412027,
+        "count": 71818.0
+    },
+    {
+        "key": "cram.com",
+        "co2": 0.8363211421705055,
+        "count": 19469.0
+    },
+    {
+        "key": "idownloadblog.com",
+        "co2": 0.6770195620358186,
+        "count": 19976.0
+    },
+    {
+        "key": "travelmath.com",
+        "co2": 0.3048618637943188,
+        "count": 17681.0
+    },
+    {
+        "key": "flipboard.app@android",
+        "co2": 0.2326597392182516,
+        "count": 31401.0
+    },
+    {
+        "key": "geology.com",
+        "co2": 0.3361562088977273,
+        "count": 28709.0
+    },
+    {
+        "key": "onegreenplanet.org",
+        "co2": 0.5027910393033486,
+        "count": 20964.0
+    },
+    {
+        "key": "timesofisrael.com",
+        "co2": 0.40762346818699047,
+        "count": 28849.0
+    },
+    {
+        "key": "com.tripledot.woodoku@android",
+        "co2": 0.23560722004370963,
+        "count": 6471.0
+    },
+    {
+        "key": "metservice.com",
+        "co2": 0.3695288580582421,
+        "count": 28041.0
+    },
+    {
+        "key": "ehow.com",
+        "co2": 0.5719251489140135,
+        "count": 21280.0
+    },
+    {
+        "key": "epicstream.com",
+        "co2": 0.33425373792026336,
+        "count": 32415.0
+    },
+    {
+        "key": "gameskinny.com",
+        "co2": 0.2755345867815611,
+        "count": 108622.0
+    },
+    {
+        "key": "sky.com",
+        "co2": 0.43462573359888823,
+        "count": 17186.0
+    },
+    {
+        "key": "beachgrit.com",
+        "co2": 0.8754871205700921,
+        "count": 16161.0
+    },
+    {
+        "key": "247mahjong.com",
+        "co2": 0.29889598148653934,
+        "count": 65168.0
+    },
+    {
+        "key": "gardeningknowhow.com",
+        "co2": 0.320740688322007,
+        "count": 35978.0
+    },
+    {
+        "key": "marthastewart.com",
+        "co2": 0.2852697418311474,
+        "count": 34173.0
+    },
+    {
+        "key": "tvguide.com",
+        "co2": 0.5637552932276981,
+        "count": 38295.0
+    },
+    {
+        "key": "who.com.au",
+        "co2": 0.33973782587104007,
+        "count": 43369.0
+    },
+    {
+        "key": "com.spacegame.solitaire.basic@android",
+        "co2": 0.22915695484143295,
+        "count": 11717.0
+    },
+    {
+        "key": "shmoop.com",
+        "co2": 0.7295824629004004,
+        "count": 60293.0
+    },
+    {
+        "key": "diva-magazine.com",
+        "co2": 0.3428102168027598,
+        "count": 59266.0
+    },
+    {
+        "key": "tradingpost.com.au",
+        "co2": 0.2537512522410188,
+        "count": 20041.0
+    },
+    {
+        "key": "com.digitalchemy.calculator.freedecimal@android",
+        "co2": 0.23506677029988485,
+        "count": 12228.0
+    },
+    {
+        "key": "com.spanishdict.spanishdict@android",
+        "co2": 0.23793752307247615,
+        "count": 4809.0
+    },
+    {
+        "key": "numbeo.com",
+        "co2": 0.7824175442266866,
+        "count": 22190.0
+    },
+    {
+        "key": "sammobile.com",
+        "co2": 0.41324245967033907,
+        "count": 29034.0
+    },
+    {
+        "key": "calculator.net",
+        "co2": 0.24304123235826955,
+        "count": 20241.0
+    },
+    {
+        "key": "com.gosub60.sol5@android",
+        "co2": 0.24145705006154694,
+        "count": 16739.0
+    },
+    {
+        "key": "com.spacegame.basic3@android",
+        "co2": 0.22696922158269447,
+        "count": 17151.0
+    },
+    {
+        "key": "afr.com",
+        "co2": 0.2539407168522034,
+        "count": 14515.0
+    },
+    {
+        "key": "cpubenchmark.net",
+        "co2": 0.567563717453589,
+        "count": 12358.0
+    },
+    {
+        "key": "eenadu.net",
+        "co2": 0.7259207876708246,
+        "count": 25603.0
+    },
+    {
+        "key": "footwearnews.com",
+        "co2": 0.48906887335432814,
+        "count": 35374.0
+    },
+    {
+        "key": "breakingmuscle.com",
+        "co2": 0.2850645771142572,
+        "count": 34792.0
+    },
+    {
+        "key": "com.bitmango.go.mahjongsolitaireclassic@android",
+        "co2": 0.23441659341308627,
+        "count": 7870.0
+    },
+    {
+        "key": "com.tripledot.solitaire@android",
+        "co2": 0.2344907948290569,
+        "count": 27072.0
+    },
+    {
+        "key": "indiewire.com",
+        "co2": 0.48621358030869766,
+        "count": 16951.0
+    },
+    {
+        "key": "bleedingcool.com",
+        "co2": 0.6276250583572959,
+        "count": 65860.0
+    },
+    {
+        "key": "com.audiomack@android",
+        "co2": 0.2327517944455813,
+        "count": 5352.0
+    },
+    {
+        "key": "foodiecrush.com",
+        "co2": 0.32246304974221596,
+        "count": 29826.0
+    },
+    {
+        "key": "geeksforgeeks.org",
+        "co2": 0.4427665867719246,
+        "count": 62761.0
+    },
+    {
+        "key": "pcmag.com",
+        "co2": 0.9187192756975662,
+        "count": 21814.0
+    },
+    {
+        "key": "dailyforest.com",
+        "co2": 0.4170357378452416,
+        "count": 264132.0
+    },
+    {
+        "key": "spanishdict-translator/id332510494@ios",
+        "co2": 0.2508668828084446,
+        "count": 4796.0
+    },
+    {
+        "key": "centralwesterndaily.com.au",
+        "co2": 0.4334748616770386,
+        "count": 14018.0
+    },
+    {
+        "key": "com.livescore@android",
+        "co2": 0.23306546833818484,
+        "count": 28487.0
+    },
+    {
+        "key": "countryliving.com",
+        "co2": 0.2761868283334275,
+        "count": 46452.0
+    },
+    {
+        "key": "owlcation.com",
+        "co2": 0.49343055281935333,
+        "count": 37257.0
+    },
+    {
+        "key": "sudoku.puzzle.free.game.brain@android",
+        "co2": 0.23420583697097852,
+        "count": 27310.0
+    },
+    {
+        "key": "clairekcreations.com",
+        "co2": 0.28588076162494747,
+        "count": 27095.0
+    },
+    {
+        "key": "com.hornet.android@android",
+        "co2": 0.2435393292153419,
+        "count": 3227.0
+    },
+    {
+        "key": "rugby.league.live@android",
+        "co2": 0.24135167639290045,
+        "count": 35765.0
+    },
+    {
+        "key": "speedtest.net",
+        "co2": 0.3414098414377733,
+        "count": 29260.0
+    },
+    {
+        "key": "apartmenttherapy.com",
+        "co2": 0.3860585197537679,
+        "count": 27728.0
+    },
+    {
+        "key": "com.peoplefun.wordsearch@android",
+        "co2": 0.2334884623972257,
+        "count": 20861.0
+    },
+    {
+        "key": "itipfooty.com.au",
+        "co2": 0.3496635498684157,
+        "count": 14349.0
+    },
+    {
+        "key": "justapinch.com",
+        "co2": 0.3251151697418446,
+        "count": 22911.0
+    },
+    {
+        "key": "kawalingpinoy.com",
+        "co2": 0.28701711633173094,
+        "count": 29189.0
+    },
+    {
+        "key": "supercars.com",
+        "co2": 0.248874302316684,
+        "count": 97124.0
+    },
+    {
+        "key": "celtsarehere.com",
+        "co2": 0.6099684993317783,
+        "count": 13101.0
+    },
+    {
+        "key": "com.scopely.wheeloffortune@android",
+        "co2": 0.23392359054264222,
+        "count": 10897.0
+    },
+    {
+        "key": "kannadaprabha.com",
+        "co2": 0.5145052037952141,
+        "count": 47135.0
+    },
+    {
+        "key": "pinchofyum.com",
+        "co2": 0.28307439920060856,
+        "count": 36488.0
+    },
+    {
+        "key": "com.easybrain.jigsaw.puzzles@android",
+        "co2": 0.2339758181470261,
+        "count": 19424.0
+    },
+    {
+        "key": "futwiz.com",
+        "co2": 0.6590639523448784,
+        "count": 89832.0
+    },
+    {
+        "key": "khaosod.co.th",
+        "co2": 0.38149795339764114,
+        "count": 28856.0
+    },
+    {
+        "key": "metvuw.com",
+        "co2": 0.21953990976121934,
+        "count": 29455.0
+    },
+    {
+        "key": "askamanager.org",
+        "co2": 0.5082090027040285,
+        "count": 46197.0
+    },
+    {
+        "key": "lemonblossoms.com",
+        "co2": 0.29017289277822855,
+        "count": 36697.0
+    },
+    {
+        "key": "theroar.com.au",
+        "co2": 0.8143155013478657,
+        "count": 35529.0
+    },
+    {
+        "key": "commercialrealestate.com.au",
+        "co2": 0.2764405401545839,
+        "count": 28015.0
+    },
+    {
+        "key": "online-stopwatch.com",
+        "co2": 0.30337084191159297,
+        "count": 12545.0
+    },
+    {
+        "key": "lifeloveandsugar.com",
+        "co2": 0.28717583286348414,
+        "count": 33476.0
+    },
+    {
+        "key": "tmz.com",
+        "co2": 0.27643062280661373,
+        "count": 10484.0
+    },
+    {
+        "key": "makeupalley.com",
+        "co2": 0.25348819467596095,
+        "count": 31985.0
+    },
+    {
+        "key": "thefamouspeople.com",
+        "co2": 0.6246231537202447,
+        "count": 37121.0
+    },
+    {
+        "key": "wired.com",
+        "co2": 0.3885586667831476,
+        "count": 43636.0
+    },
+    {
+        "key": "helpdeskgeek.com",
+        "co2": 0.5257189449658971,
+        "count": 24309.0
+    },
+    {
+        "key": "miniwebtool.com",
+        "co2": 0.5805263873000728,
+        "count": 14498.0
+    },
+    {
+        "key": "rankedboost.com",
+        "co2": 0.3909829589147379,
+        "count": 16773.0
+    },
+    {
+        "key": "aussiehomebrewer.com",
+        "co2": 0.28285946964703074,
+        "count": 26855.0
+    },
+    {
+        "key": "farmonlineweather.com.au",
+        "co2": 0.38453012191975666,
+        "count": 38945.0
+    },
+    {
+        "key": "homebrewtalk.com",
+        "co2": 0.29199353958007684,
+        "count": 25345.0
+    },
+    {
+        "key": "whiskaffair.com",
+        "co2": 0.2903139701348307,
+        "count": 28175.0
+    },
+    {
+        "key": "whattoexpect.com",
+        "co2": 0.2865220900862753,
+        "count": 9785.0
+    },
+    {
+        "key": "bonappetit.com",
+        "co2": 0.40042568409311896,
+        "count": 27042.0
+    },
+    {
+        "key": "com.easybrain.block.puzzle.games@android",
+        "co2": 0.23476824748142383,
+        "count": 21999.0
+    },
+    {
+        "key": "foxbusiness.com",
+        "co2": 0.28142581609119094,
+        "count": 17020.0
+    },
+    {
+        "key": "pitchfork.com",
+        "co2": 0.2642080562440608,
+        "count": 28109.0
+    },
+    {
+        "key": "standard.net.au",
+        "co2": 0.39963924674109286,
+        "count": 20960.0
+    },
+    {
+        "key": "com.zynga.wwf2.free@android",
+        "co2": 0.23208221155879474,
+        "count": 11598.0
+    },
+    {
+        "key": "dcrainmaker.com",
+        "co2": 0.28318356566570985,
+        "count": 19337.0
+    },
+    {
+        "key": "islamicfinder.org",
+        "co2": 0.5260064319473298,
+        "count": 29012.0
+    },
+    {
+        "key": "epicurious.com",
+        "co2": 0.2689093334202317,
+        "count": 21112.0
+    },
+    {
+        "key": "gosunoob.com",
+        "co2": 0.33952286626808614,
+        "count": 14368.0
+    },
+    {
+        "key": "ifoodreal.com",
+        "co2": 0.2854572418477723,
+        "count": 20680.0
+    },
+    {
+        "key": "snopes.com",
+        "co2": 0.5953638060322926,
+        "count": 66347.0
+    },
+    {
+        "key": "backpack.tf",
+        "co2": 0.30645644126322874,
+        "count": 27425.0
+    },
+    {
+        "key": "conserve-energy-future.com",
+        "co2": 0.3073707987992907,
+        "count": 22660.0
+    },
+    {
+        "key": "gossiplankanews.com",
+        "co2": 0.2253348767712649,
+        "count": 3097.0
+    },
+    {
+        "key": "2kmtcentral.com",
+        "co2": 0.270666448985255,
+        "count": 19936.0
+    },
+    {
+        "key": "cdn-apple.com",
+        "co2": 0.5179165242508429,
+        "count": 21781.0
+    },
+    {
+        "key": "com.gramgames.tenten@android",
+        "co2": 0.23669049906257722,
+        "count": 16620.0
+    },
+    {
+        "key": "com.nighp.babytracker_android@android",
+        "co2": 0.251919099521155,
+        "count": 12565.0
+    },
+    {
+        "key": "cbr.com",
+        "co2": 0.7216808822867463,
+        "count": 19692.0
+    },
+    {
+        "key": "kotaku.com.au",
+        "co2": 0.26116936563990223,
+        "count": 13553.0
+    },
+    {
+        "key": "constative.com",
+        "co2": 0.5244854121156838,
+        "count": 40819.0
+    },
+    {
+        "key": "dafont.com",
+        "co2": 0.9781785941330885,
+        "count": 31796.0
+    },
+    {
+        "key": "inews.co.uk",
+        "co2": 0.38173985585734505,
+        "count": 26825.0
+    },
+    {
+        "key": "mobafire.com",
+        "co2": 0.3290661269244352,
+        "count": 20938.0
+    },
+    {
+        "key": "tvtonight.com.au",
+        "co2": 0.2636210639583692,
+        "count": 19942.0
+    },
+    {
+        "key": "uk.co.aifactory.solitairefree@android",
+        "co2": 0.2496449998736196,
+        "count": 6241.0
+    },
+    {
+        "key": "vnexpress.net",
+        "co2": 0.6063014082143718,
+        "count": 2659.0
+    },
+    {
+        "key": "com.bravolol.bravolang.englishchinesecdictionary@android",
+        "co2": 0.23352924729088842,
+        "count": 5007.0
+    },
+    {
+        "key": "dlisted.com",
+        "co2": 0.6106628918359838,
+        "count": 23775.0
+    },
+    {
+        "key": "gardenbetty.com",
+        "co2": 0.2843028968523391,
+        "count": 51106.0
+    },
+    {
+        "key": "boxingnews24.com",
+        "co2": 0.40020291435398647,
+        "count": 47769.0
+    },
+    {
+        "key": "livestrong.com",
+        "co2": 0.5385890724214639,
+        "count": 23223.0
+    },
+    {
+        "key": "macrobusiness.com.au",
+        "co2": 0.2447839018952808,
+        "count": 12416.0
+    },
+    {
+        "key": "trustedpsychicmediums.com",
+        "co2": 0.2782747554017272,
+        "count": 31882.0
+    },
+    {
+        "key": "com.hamropatro@android",
+        "co2": 0.2344250547096451,
+        "count": 7250.0
+    },
+    {
+        "key": "com.ucdevs.jcross@android",
+        "co2": 0.23455476016356347,
+        "count": 7009.0
+    },
+    {
+        "key": "heysigmund.com",
+        "co2": 0.5032842919895868,
+        "count": 49228.0
+    },
+    {
+        "key": "ohsnapletseat.com",
+        "co2": 0.2936781417376854,
+        "count": 24495.0
+    },
+    {
+        "key": "com.hi5.app@android",
+        "co2": 0.237522011831075,
+        "count": 5725.0
+    },
+    {
+        "key": "twopeasandtheirpod.com",
+        "co2": 0.3227445418389533,
+        "count": 22831.0
+    },
+    {
+        "key": "videogames.si.com",
+        "co2": 0.47172570956877613,
+        "count": 7167.0
+    },
+    {
+        "key": "worldtimeserver.com",
+        "co2": 0.26735999943400884,
+        "count": 19360.0
+    },
+    {
+        "key": "asianwiki.com",
+        "co2": 0.2682376260344801,
+        "count": 24391.0
+    },
+    {
+        "key": "silvertails.net",
+        "co2": 0.3030542538579866,
+        "count": 21977.0
+    },
+    {
+        "key": "averiecooks.com",
+        "co2": 0.28617571399731867,
+        "count": 18430.0
+    },
+    {
+        "key": "easybib.com",
+        "co2": 0.27794670534685995,
+        "count": 30152.0
+    },
+    {
+        "key": "kayak.com.au",
+        "co2": 0.2513009575417949,
+        "count": 44559.0
+    },
+    {
+        "key": "ajitjalandhar.com",
+        "co2": 0.48816173110501326,
+        "count": 72933.0
+    },
+    {
+        "key": "com.astarsoftware.euchre@android",
+        "co2": 0.22718595099983296,
+        "count": 12578.0
+    },
+    {
+        "key": "exceljet.net",
+        "co2": 0.42487424435868126,
+        "count": 33334.0
+    },
+    {
+        "key": "chinatimes.com",
+        "co2": 1.9940921348505503,
+        "count": 11747.0
+    },
+    {
+        "key": "eatthis.com",
+        "co2": 0.27748331791362196,
+        "count": 60601.0
+    },
+    {
+        "key": "com.zombodroid.MemeGenerator@android",
+        "co2": 0.23364883193079888,
+        "count": 1356.0
+    },
+    {
+        "key": "tomandlorenzo.com",
+        "co2": 0.4631180345568301,
+        "count": 16160.0
+    },
+    {
+        "key": "com.genius.android@android",
+        "co2": 0.2329481387006874,
+        "count": 14701.0
+    },
+    {
+        "key": "thewindowsclub.com",
+        "co2": 1.5416764389738047,
+        "count": 58648.0
+    },
+    {
+        "key": "com.peoplefun.wordstacks@android",
+        "co2": 0.23330301536130912,
+        "count": 9025.0
+    },
+    {
+        "key": "mlive.com",
+        "co2": 0.3027908321834471,
+        "count": 5977.0
+    },
+    {
+        "key": "mydramalist.com",
+        "co2": 0.4278670747528494,
+        "count": 10253.0
+    },
+    {
+        "key": "typeracer.com",
+        "co2": 1.206114706249689,
+        "count": 21712.0
+    },
+    {
+        "key": "com.kokteyl.goal@android",
+        "co2": 0.23433999543043968,
+        "count": 9435.0
+    },
+    {
+        "key": "com.reachjunction.card.game.solitaire@android",
+        "co2": 0.23406905146055973,
+        "count": 4447.0
+    },
+    {
+        "key": "paper-io-2/id1423046460@ios",
+        "co2": 0.23619997488041958,
+        "count": 7954.0
+    },
+    {
+        "key": "readersdigest.com.au",
+        "co2": 0.577618639504482,
+        "count": 21025.0
+    },
+    {
+        "key": "com.appgeneration.itunerfree@android",
+        "co2": 0.23287591888233722,
+        "count": 4520.0
+    },
+    {
+        "key": "se.maginteractive.wordbrain@android",
+        "co2": 0.23439340254401836,
+        "count": 8284.0
+    },
+    {
+        "key": "bodybuilding.com",
+        "co2": 0.6768739288384538,
+        "count": 20255.0
+    },
+    {
+        "key": "nonchalantmagazine.com",
+        "co2": 0.7002124642115158,
+        "count": 17939.0
+    },
+    {
+        "key": "vox.com",
+        "co2": 0.2848268052740286,
+        "count": 15018.0
+    },
+    {
+        "key": "crictracker.com",
+        "co2": 0.8995217171194998,
+        "count": 17253.0
+    },
+    {
+        "key": "foxyfolksy.com",
+        "co2": 0.34437900649489256,
+        "count": 20564.0
+    },
+    {
+        "key": "oceandraw.com",
+        "co2": 0.44521183879937243,
+        "count": 2196.0
+    },
+    {
+        "key": "com.freegame.solitaire.basic2@android",
+        "co2": 0.23546658180522395,
+        "count": 13201.0
+    },
+    {
+        "key": "mlb.com",
+        "co2": 0.44341249160276985,
+        "count": 16877.0
+    },
+    {
+        "key": "apnews.com",
+        "co2": 0.2574190817072297,
+        "count": 1075.0
+    },
+    {
+        "key": "myfitnesspal.com",
+        "co2": 0.22543647135182163,
+        "count": 13526.0
+    },
+    {
+        "key": "rogerebert.com",
+        "co2": 0.3443928426092852,
+        "count": 17831.0
+    },
+    {
+        "key": "uk.co.aifactory.heartsfree@android",
+        "co2": 0.26001657740657813,
+        "count": 4036.0
+    },
+    {
+        "key": "com.jewels.gems.android@android",
+        "co2": 0.23170303114156343,
+        "count": 8393.0
+    },
+    {
+        "key": "homeone.com.au",
+        "co2": 0.5928983792140631,
+        "count": 9725.0
+    },
+    {
+        "key": "hymnary.org",
+        "co2": 0.38465893285013913,
+        "count": 25855.0
+    },
+    {
+        "key": "juliasalbum.com",
+        "co2": 0.28412596422390757,
+        "count": 24995.0
+    },
+    {
+        "key": "sweetpeasandsaffron.com",
+        "co2": 0.2882186996418194,
+        "count": 25880.0
+    },
+    {
+        "key": "co.peeksoft.stocks@android",
+        "co2": 0.22975725353049548,
+        "count": 3403.0
+    },
+    {
+        "key": "com.cardgame.solitaire@android",
+        "co2": 0.23256531020238663,
+        "count": 9741.0
+    },
+    {
+        "key": "com.rikkigames.solsuite@android",
+        "co2": 0.23144933201137216,
+        "count": 7787.0
+    },
+    {
+        "key": "malaymail.com",
+        "co2": 1.107336523659418,
+        "count": 8094.0
+    },
+    {
+        "key": "astrologyzone.com",
+        "co2": 0.3525887153754995,
+        "count": 51047.0
+    },
+    {
+        "key": "abcnews.go.com",
+        "co2": 0.2507593087646428,
+        "count": 12377.0
+    },
+    {
+        "key": "greyhound-data.com",
+        "co2": 0.37070902871425104,
+        "count": 4041.0
+    },
+    {
+        "key": "jagranjosh.com",
+        "co2": 1.398941024242992,
+        "count": 31281.0
+    },
+    {
+        "key": "org.detikcom.rss@android",
+        "co2": 0.2311935381470305,
+        "count": 3781.0
+    },
+    {
+        "key": "spurs-web.com",
+        "co2": 0.3931726496400389,
+        "count": 10992.0
+    },
+    {
+        "key": "boingboing.net",
+        "co2": 0.7620674366219196,
+        "count": 20050.0
+    },
+    {
+        "key": "net.zedge.android@android",
+        "co2": 0.23206646604619982,
+        "count": 8465.0
+    },
+    {
+        "key": "thisismoney.co.uk",
+        "co2": 0.4227023616107477,
+        "count": 17654.0
+    },
+    {
+        "key": "tjrwrestling.net",
+        "co2": 0.3163221732553546,
+        "count": 28625.0
+    },
+    {
+        "key": "works.jubilee.timetree@android",
+        "co2": 0.23039120992837162,
+        "count": 8928.0
+    },
+    {
+        "key": "asiantrader.biz",
+        "co2": 1.7982205971925973,
+        "count": 10565.0
+    },
+    {
+        "key": "com.tumblr@android",
+        "co2": 0.22971172544075885,
+        "count": 27296.0
+    },
+    {
+        "key": "golfwrx.com",
+        "co2": 0.27400900585897453,
+        "count": 15142.0
+    },
+    {
+        "key": "spotify.com",
+        "co2": 0.21908516075395607,
+        "count": 199610.0
+    },
+    {
+        "key": "nigella.com",
+        "co2": 0.6006078394155299,
+        "count": 14593.0
+    },
+    {
+        "key": "taboolanews.com",
+        "co2": 0.5392187006365537,
+        "count": 5156.0
+    },
+    {
+        "key": "adrecover.com",
+        "co2": 0.25895347383028533,
+        "count": 26435.0
+    },
+    {
+        "key": "todaysparent.com",
+        "co2": 0.28038257133460265,
+        "count": 20495.0
+    },
+    {
+        "key": "archdaily.com",
+        "co2": 0.25481142763541503,
+        "count": 29968.0
+    },
+    {
+        "key": "futhead.com",
+        "co2": 1.0118545752003578,
+        "count": 11012.0
+    },
+    {
+        "key": "greatist.com",
+        "co2": 0.24671932382750958,
+        "count": 11288.0
+    },
+    {
+        "key": "myweather2.com",
+        "co2": 0.3105651233354766,
+        "count": 37939.0
+    },
+    {
+        "key": "bgr.com",
+        "co2": 0.48061783991058943,
+        "count": 5461.0
+    },
+    {
+        "key": "com.amikulich.babysleep@android",
+        "co2": 0.23249101876580186,
+        "count": 3021.0
+    },
+    {
+        "key": "jp.ne.ibis.ibispaintx.app@android",
+        "co2": 0.23325139364146016,
+        "count": 7474.0
+    },
+    {
+        "key": "kitco.com",
+        "co2": 0.5413087595223797,
+        "count": 20041.0
+    },
+    {
+        "key": "mensjournal.com",
+        "co2": 0.846086633148508,
+        "count": 17668.0
+    },
+    {
+        "key": "com.flightradar24free@android",
+        "co2": 0.22808758271348734,
+        "count": 11651.0
+    },
+    {
+        "key": "nationalgeographic.com",
+        "co2": 0.27775480537732994,
+        "count": 11892.0
+    },
+    {
+        "key": "plantbasednews.org",
+        "co2": 0.2497313669879223,
+        "count": 1329.0
+    },
+    {
+        "key": "biblestudytools.com",
+        "co2": 0.34368893702477293,
+        "count": 17548.0
+    },
+    {
+        "key": "com.badoo.mobile@android",
+        "co2": 0.2300648764990099,
+        "count": 2765.0
+    },
+    {
+        "key": "freebmd.org.uk",
+        "co2": 0.44134268628560547,
+        "count": 11786.0
+    },
+    {
+        "key": "mercurynews.com",
+        "co2": 0.4433588047654386,
+        "count": 5403.0
+    },
+    {
+        "key": "neopets.com",
+        "co2": 0.878372592404187,
+        "count": 5520.0
+    },
+    {
+        "key": "com.buzzfeed.android@android",
+        "co2": 0.22798072654451607,
+        "count": 12351.0
+    },
+    {
+        "key": "com.lhpstudio.wooden@android",
+        "co2": 0.23623566109666783,
+        "count": 6485.0
+    },
+    {
+        "key": "com.mobilefootie.wc2010@android",
+        "co2": 0.2339883140190972,
+        "count": 75706.0
+    },
+    {
+        "key": "familyminded.com",
+        "co2": 0.2606327858253138,
+        "count": 34244.0
+    },
+    {
+        "key": "hobbylark.com",
+        "co2": 0.48972396305580845,
+        "count": 25879.0
+    },
+    {
+        "key": "uk.co.aifactory.ginrummyfree@android",
+        "co2": 0.2421997723618428,
+        "count": 5412.0
+    },
+    {
+        "key": "willcookforsmiles.com",
+        "co2": 0.29458149623275565,
+        "count": 30732.0
+    },
+    {
+        "key": "net.ibexsolutions.flow8@android",
+        "co2": 0.23652458160207465,
+        "count": 3639.0
+    },
+    {
+        "key": "io.voodoo.paper2@android",
+        "co2": 0.2346622457234121,
+        "count": 13175.0
+    },
+    {
+        "key": "tagged.com",
+        "co2": 0.3814789614009453,
+        "count": 7585.0
+    },
+    {
+        "key": "com.easybrain.nonogram@android",
+        "co2": 0.23320366214019989,
+        "count": 13670.0
+    },
+    {
+        "key": "thecourier.com.au",
+        "co2": 0.40179159178743123,
+        "count": 11614.0
+    },
+    {
+        "key": "cheapies.nz",
+        "co2": 0.5430492971068724,
+        "count": 14270.0
+    },
+    {
+        "key": "com.mxtech.videoplayer.ad@android",
+        "co2": 0.2494902127684174,
+        "count": 10540.0
+    },
+    {
+        "key": "org.zwanoo.android.speedtest@android",
+        "co2": 0.23516448112584484,
+        "count": 1680.0
+    },
+    {
+        "key": "sunlive.co.nz",
+        "co2": 0.2644949706754838,
+        "count": 5407.0
+    },
+    {
+        "key": "westernadvocate.com.au",
+        "co2": 0.43043431500253526,
+        "count": 8537.0
+    },
+    {
+        "key": "com.fullersystems.cribbage@android",
+        "co2": 0.2226396764742253,
+        "count": 2710.0
+    },
+    {
+        "key": "com.tesseractmobile.solitairefreepack@android",
+        "co2": 0.23551330695911618,
+        "count": 3720.0
+    },
+    {
+        "key": "macworld.com",
+        "co2": 0.41341635444416774,
+        "count": 9902.0
+    },
+    {
+        "key": "malaysiakini.com",
+        "co2": 0.7140669863713198,
+        "count": 10562.0
+    },
+    {
+        "key": "tribalfootball.com",
+        "co2": 0.351531561326548,
+        "count": 12879.0
+    },
+    {
+        "key": "cruisersforum.com",
+        "co2": 0.2931708426740379,
+        "count": 25346.0
+    },
+    {
+        "key": "techwalla.com",
+        "co2": 0.561358754883859,
+        "count": 7752.0
+    },
+    {
+        "key": "appunwrapper.com",
+        "co2": 0.3256459513667613,
+        "count": 40995.0
+    },
+    {
+        "key": "com.hbwares.wordfeud.free@android",
+        "co2": 0.228325274253796,
+        "count": 3287.0
+    },
+    {
+        "key": "com.innovaptor.izurvive@android",
+        "co2": 0.22890958936099445,
+        "count": 14384.0
+    },
+    {
+        "key": "nickiswift.com",
+        "co2": 0.3711551667549654,
+        "count": 46529.0
+    },
+    {
+        "key": "chefsavvy.com",
+        "co2": 0.2904352194464675,
+        "count": 17792.0
+    },
+    {
+        "key": "christinesrecipes.com",
+        "co2": 0.2924647300737521,
+        "count": 14233.0
+    },
+    {
+        "key": "com.bigduckgames.flowhexes@android",
+        "co2": 0.2293261697889761,
+        "count": 3112.0
+    },
+    {
+        "key": "lunapic.com",
+        "co2": 0.27687936918537204,
+        "count": 8156.0
+    },
+    {
+        "key": "sweetashoney.co",
+        "co2": 0.32439428140896814,
+        "count": 27521.0
+    },
+    {
+        "key": "com.meetup@android",
+        "co2": 0.23363839407698897,
+        "count": 3289.0
+    },
+    {
+        "key": "jigidi.com",
+        "co2": 0.27496227152282415,
+        "count": 9527.0
+    },
+    {
+        "key": "kueez.com",
+        "co2": 0.40500219817347677,
+        "count": 14461.0
+    },
+    {
+        "key": "nme.com",
+        "co2": 0.4599983487465543,
+        "count": 8640.0
+    },
+    {
+        "key": "com.intsig.camscanner@android",
+        "co2": 0.23158932139132324,
+        "count": 4641.0
+    },
+    {
+        "key": "k12reader.com",
+        "co2": 0.4285045926332446,
+        "count": 11124.0
+    },
+    {
+        "key": "msnbc.com",
+        "co2": 0.2611625467747675,
+        "count": 2533.0
+    },
+    {
+        "key": "seventeen.com",
+        "co2": 0.2755454659255865,
+        "count": 18231.0
+    },
+    {
+        "key": "akinator.com",
+        "co2": 1.6246879964523335,
+        "count": 30525.0
+    },
+    {
+        "key": "allfreecrochet.com",
+        "co2": 0.8388695265946868,
+        "count": 6324.0
+    },
+    {
+        "key": "com.imo.android.imoim@android",
+        "co2": 0.23268121866114705,
+        "count": 9981.0
+    },
+    {
+        "key": "hungliaonline.com",
+        "co2": 1.465280688563299,
+        "count": 97428.0
+    },
+    {
+        "key": "com.flightaware.android.liveFlightTracker@android",
+        "co2": 0.23320153948750028,
+        "count": 4742.0
+    },
+    {
+        "key": "playstationtrophies.org",
+        "co2": 0.3347186400161224,
+        "count": 17202.0
+    },
+    {
+        "key": "oilprice.com",
+        "co2": 0.5523902600117728,
+        "count": 14751.0
+    },
+    {
+        "key": "twoplayergames.org",
+        "co2": 0.5506993466608375,
+        "count": 58712.0
+    },
+    {
+        "key": "ait.podka@android",
+        "co2": 0.2295152265494246,
+        "count": 4431.0
+    },
+    {
+        "key": "bikeforums.net",
+        "co2": 0.48842725337497167,
+        "count": 16099.0
+    },
+    {
+        "key": "com.karmangames.canasta@android",
+        "co2": 0.23526524208872834,
+        "count": 4340.0
+    },
+    {
+        "key": "com.narvii.amino.master@android",
+        "co2": 0.23352366842050234,
+        "count": 16957.0
+    },
+    {
+        "key": "fanfooty.com.au",
+        "co2": 0.5789865188943998,
+        "count": 193283.0
+    },
+    {
+        "key": "optus.com.au",
+        "co2": 0.4686777996148371,
+        "count": 53410.0
+    },
+    {
+        "key": "tennisexplorer.com",
+        "co2": 0.2878981693697646,
+        "count": 22592.0
+    },
+    {
+        "key": "wisden.com",
+        "co2": 0.5119961097582483,
+        "count": 59269.0
+    },
+    {
+        "key": "greedyfinance.com",
+        "co2": 0.6753573819318598,
+        "count": 4644.0
+    },
+    {
+        "key": "laineygossip.com",
+        "co2": 0.30703094831099315,
+        "count": 14158.0
+    },
+    {
+        "key": "purseblog.com",
+        "co2": 0.30629007328837293,
+        "count": 15753.0
+    },
+    {
+        "key": "tdpri.com",
+        "co2": 0.3232182346495483,
+        "count": 11737.0
+    },
+    {
+        "key": "tunein.com",
+        "co2": 0.304997431341617,
+        "count": 22681.0
+    },
+    {
+        "key": "yorkshireeveningpost.co.uk",
+        "co2": 1.1952046057448675,
+        "count": 22618.0
+    },
+    {
+        "key": "com.mobilityware.PyramidFree@android",
+        "co2": 0.2319994781598943,
+        "count": 3462.0
+    },
+    {
+        "key": "meaww.com",
+        "co2": 0.6569417485611658,
+        "count": 39534.0
+    },
+    {
+        "key": "mnn.Android@android",
+        "co2": 0.22585119762255837,
+        "count": 3804.0
+    },
+    {
+        "key": "threenow.co.nz",
+        "co2": 0.28715467691961133,
+        "count": 157143.0
+    },
+    {
+        "key": "com.laurencedawson.reddit_sync@android",
+        "co2": 0.22922522107300872,
+        "count": 6504.0
+    },
+    {
+        "key": "pastemagazine.com",
+        "co2": 0.30558641328059233,
+        "count": 30593.0
+    },
+    {
+        "key": "com.imvu.mobilecordova@android",
+        "co2": 0.22830893086114074,
+        "count": 4256.0
+    },
+    {
+        "key": "eva.vn",
+        "co2": 0.5861305923942863,
+        "count": 14416.0
+    },
+    {
+        "key": "googleusercontent.com",
+        "co2": 0.22372851986984485,
+        "count": 23031.0
+    },
+    {
+        "key": "time.com",
+        "co2": 0.34290960431899725,
+        "count": 65299.0
+    },
+    {
+        "key": "livescience.com",
+        "co2": 0.8889458327247547,
+        "count": 4774.0
+    },
+    {
+        "key": "optussport.tv",
+        "co2": 0.4667436529346542,
+        "count": 71214.0
+    },
+    {
+        "key": "supercheats.com",
+        "co2": 0.30619606659857507,
+        "count": 42605.0
+    },
+    {
+        "key": "convertunits.com",
+        "co2": 0.3408593455645206,
+        "count": 24721.0
+    },
+    {
+        "key": "hearthookhome.com",
+        "co2": 0.2900903389800374,
+        "count": 14059.0
+    },
+    {
+        "key": "tinybeans.com",
+        "co2": 0.4309100193469597,
+        "count": 9924.0
+    },
+    {
+        "key": "altpress.com",
+        "co2": 0.4790305017944958,
+        "count": 6667.0
+    },
+    {
+        "key": "com.babycenter.pregnancytracker@android",
+        "co2": 0.23289795508341182,
+        "count": 2366.0
+    },
+    {
+        "key": "com.handmark.sportcaster@android",
+        "co2": 0.2319058840833522,
+        "count": 3825.0
+    },
+    {
+        "key": "coconuts.co",
+        "co2": 0.4635395818584631,
+        "count": 9149.0
+    },
+    {
+        "key": "complex.com",
+        "co2": 0.39863001329414816,
+        "count": 23942.0
+    },
+    {
+        "key": "muscleandfitness.com",
+        "co2": 0.47252191014173545,
+        "count": 20282.0
+    },
+    {
+        "key": "taiwannews.com.tw",
+        "co2": 0.5582136310311011,
+        "count": 28553.0
+    },
+    {
+        "key": "weather-and-climate.com",
+        "co2": 0.5580193294923946,
+        "count": 15466.0
+    },
+    {
+        "key": "bein-sports-tr/id434619978@ios",
+        "co2": 0.23972789626923394,
+        "count": 2999.0
+    },
+    {
+        "key": "com.mobilityware.spider@android",
+        "co2": 0.24906446061949325,
+        "count": 6927.0
+    },
+    {
+        "key": "economictimes.com",
+        "co2": 1.2373792201096834,
+        "count": 27769.0
+    },
+    {
+        "key": "farandwide.com",
+        "co2": 0.26393066001018706,
+        "count": 22015.0
+    },
+    {
+        "key": "food52.com",
+        "co2": 0.7355632602996044,
+        "count": 23637.0
+    },
+    {
+        "key": "gyazo.com",
+        "co2": 0.2581473128237206,
+        "count": 21295.0
+    },
+    {
+        "key": "rightmove.co.uk",
+        "co2": 0.2671436165136822,
+        "count": 9915.0
+    },
+    {
+        "key": "theprimarymarket.com",
+        "co2": 1.354751037837762,
+        "count": 104187.0
+    },
+    {
+        "key": "thescottishsun.co.uk",
+        "co2": 0.7499945034348806,
+        "count": 60240.0
+    },
+    {
+        "key": "vulture.com",
+        "co2": 0.29963123230803845,
+        "count": 10845.0
+    },
+    {
+        "key": "com.picsart.studio@android",
+        "co2": 0.23396692454614446,
+        "count": 5853.0
+    },
+    {
+        "key": "looplik.com",
+        "co2": 0.219953082124118,
+        "count": 1621.0
+    },
+    {
+        "key": "quizzclub.com",
+        "co2": 0.6006949173683422,
+        "count": 15780.0
+    },
+    {
+        "key": "sixsistersstuff.com",
+        "co2": 0.28827554731166605,
+        "count": 22551.0
+    },
+    {
+        "key": "accuradio.com",
+        "co2": 0.3635432973236774,
+        "count": 1383.0
+    },
+    {
+        "key": "dailyrecord.co.uk",
+        "co2": 0.5327575184594631,
+        "count": 6818.0
+    },
+    {
+        "key": "jugantor.com",
+        "co2": 0.6929531052111451,
+        "count": 33589.0
+    },
+    {
+        "key": "manoramaonline.com",
+        "co2": 0.5886317924656174,
+        "count": 1042.0
+    },
+    {
+        "key": "officeholidays.com",
+        "co2": 0.5354598474878254,
+        "count": 14579.0
+    },
+    {
+        "key": "panlasangpinoy.com",
+        "co2": 1.0264899531694514,
+        "count": 48428.0
+    },
+    {
+        "key": "elle.com",
+        "co2": 0.2699821051581555,
+        "count": 30122.0
+    },
+    {
+        "key": "foreignpolicy.com",
+        "co2": 0.2443657990563265,
+        "count": 4385.0
+    },
+    {
+        "key": "gq.com.au",
+        "co2": 0.26654850120334245,
+        "count": 28039.0
+    },
+    {
+        "key": "shape.com",
+        "co2": 0.2859417101917041,
+        "count": 11163.0
+    },
+    {
+        "key": "wehavekids.com",
+        "co2": 0.4967211347929359,
+        "count": 18109.0
+    },
+    {
+        "key": "active.com",
+        "co2": 0.3004792049090724,
+        "count": 9158.0
+    },
+    {
+        "key": "com.fiogonia.yatzy@android",
+        "co2": 0.22864709243859405,
+        "count": 4008.0
+    },
+    {
+        "key": "com.podcast.podcasts@android",
+        "co2": 0.23137635438743545,
+        "count": 2528.0
+    },
+    {
+        "key": "jp.gocro.smartnews.android@android",
+        "co2": 0.23199236251281616,
+        "count": 2695.0
+    },
+    {
+        "key": "looperman.com",
+        "co2": 0.6741923329096356,
+        "count": 17943.0
+    },
+    {
+        "key": "ohmyveggies.com",
+        "co2": 0.2815730156277134,
+        "count": 19370.0
+    },
+    {
+        "key": "suggest.com",
+        "co2": 0.3423617334355624,
+        "count": 158620.0
+    },
+    {
+        "key": "today.com",
+        "co2": 0.24644157065886096,
+        "count": 2353.0
+    },
+    {
+        "key": "com.sports.schedules.basketball.nba@android",
+        "co2": 0.23224343793053182,
+        "count": 2781.0
+    },
+    {
+        "key": "greatandhra.com",
+        "co2": 0.4715444558340289,
+        "count": 18552.0
+    },
+    {
+        "key": "lifehack.org",
+        "co2": 0.36606718571969404,
+        "count": 8723.0
+    },
+    {
+        "key": "platingsandpairings.com",
+        "co2": 0.3186906338577611,
+        "count": 15175.0
+    },
+    {
+        "key": "soaphub.com",
+        "co2": 0.4279889816816676,
+        "count": 47278.0
+    },
+    {
+        "key": "softschools.com",
+        "co2": 0.4845977728485494,
+        "count": 11279.0
+    },
+    {
+        "key": "air.com.freshplanet.games.SongPop2@android",
+        "co2": 0.22562921794601476,
+        "count": 3722.0
+    },
+    {
+        "key": "attackofthefanboy.com",
+        "co2": 0.2976774502034206,
+        "count": 43926.0
+    },
+    {
+        "key": "com.cjin.pokegenie.standard@android",
+        "co2": 0.23481185824419257,
+        "count": 6130.0
+    },
+    {
+        "key": "gscene.com",
+        "co2": 0.3208004601202548,
+        "count": 9844.0
+    },
+    {
+        "key": "videocardz.com",
+        "co2": 1.5396344061976686,
+        "count": 24800.0
+    },
+    {
+        "key": "com.microsoft.microsoftsolitairecollection@android",
+        "co2": 0.22926161895473682,
+        "count": 2865.0
+    },
+    {
+        "key": "lyrics.com",
+        "co2": 0.27264450253093353,
+        "count": 27148.0
+    },
+    {
+        "key": "newatlas.com",
+        "co2": 0.26861954316454556,
+        "count": 13956.0
+    },
+    {
+        "key": "pagesix.com",
+        "co2": 0.4136390564581033,
+        "count": 9564.0
+    },
+    {
+        "key": "soapcentral.com",
+        "co2": 1.4669854110627276,
+        "count": 9241.0
+    },
+    {
+        "key": "arkadium.com",
+        "co2": 0.6415887028041716,
+        "count": 15987.0
+    },
+    {
+        "key": "com.weather.Weather@android",
+        "co2": 0.23267435368008033,
+        "count": 12670.0
+    },
+    {
+        "key": "net.metapps.watersounds@android",
+        "co2": 0.22726317021349599,
+        "count": 6543.0
+    },
+    {
+        "key": "com.nordcurrent.canteenhd@android",
+        "co2": 0.23468495423770475,
+        "count": 5763.0
+    },
+    {
+        "key": "com.studioeleven.windfinder@android",
+        "co2": 0.24023399142891966,
+        "count": 3712.0
+    },
+    {
+        "key": "gaytimes.co.uk",
+        "co2": 0.24158993596191342,
+        "count": 3036.0
+    },
+    {
+        "key": "theadvocate.com.au",
+        "co2": 0.3548612734117036,
+        "count": 9596.0
+    },
+    {
+        "key": "thewrap.com",
+        "co2": 0.5444959933926957,
+        "count": 1277.0
+    },
+    {
+        "key": "tutsplus.com",
+        "co2": 0.7054060338831276,
+        "count": 9076.0
+    },
+    {
+        "key": "vecteezy.com",
+        "co2": 0.4865247879517266,
+        "count": 13684.0
+    },
+    {
+        "key": "com.funreality.software.nativefindmyiphone.lite@android",
+        "co2": 0.23217154124385142,
+        "count": 2082.0
+    },
+    {
+        "key": "jalopyjournal.com",
+        "co2": 0.560396021629739,
+        "count": 9630.0
+    },
+    {
+        "key": "townandcountrymag.com",
+        "co2": 0.27085630470766187,
+        "count": 18942.0
+    },
+    {
+        "key": "com.nhl.gc1112.free@android",
+        "co2": 0.23125595081899855,
+        "count": 5179.0
+    },
+    {
+        "key": "nba.live@android",
+        "co2": 0.23022839234619247,
+        "count": 2406.0
+    },
+    {
+        "key": "workandmoney.com",
+        "co2": 0.26038186762195226,
+        "count": 15560.0
+    },
+    {
+        "key": "fanatik.com.tr",
+        "co2": 1.135885603747029,
+        "count": 1721.0
+    },
+    {
+        "key": "photographylife.com",
+        "co2": 0.611828280469027,
+        "count": 14712.0
+    },
+    {
+        "key": "tureng.com",
+        "co2": 0.4863696538920582,
+        "count": 8696.0
+    },
+    {
+        "key": "bustle.com",
+        "co2": 0.27204849330672226,
+        "count": 6809.0
+    },
+    {
+        "key": "com.easybrain.art.puzzle@android",
+        "co2": 0.23350841945668632,
+        "count": 7207.0
+    },
+    {
+        "key": "culinaryhill.com",
+        "co2": 0.2868054362514824,
+        "count": 14755.0
+    },
+    {
+        "key": "hit.com.au",
+        "co2": 0.2534432148069418,
+        "count": 6900.0
+    },
+    {
+        "key": "totalrl.com",
+        "co2": 0.5247083396113789,
+        "count": 12741.0
+    },
+    {
+        "key": "bubbleshooter.orig@android",
+        "co2": 0.2333516386581394,
+        "count": 5080.0
+    },
+    {
+        "key": "com.graymatrix.did@android",
+        "co2": 0.2338634229810518,
+        "count": 2810.0
+    },
+    {
+        "key": "gunnerkrigg.com",
+        "co2": 0.3340872386179241,
+        "count": 5553.0
+    },
+    {
+        "key": "in.daily_puzzle.crossword@android",
+        "co2": 0.23180751867995142,
+        "count": 6807.0
+    },
+    {
+        "key": "publicholidays.com.au",
+        "co2": 0.6723299413436228,
+        "count": 9620.0
+    },
+    {
+        "key": "com.astarsoftware.hearts@android",
+        "co2": 0.23156991797059973,
+        "count": 4486.0
+    },
+    {
+        "key": "damndelicious.net",
+        "co2": 0.27579428702600717,
+        "count": 22489.0
+    },
+    {
+        "key": "pajiba.com",
+        "co2": 0.6645746186987804,
+        "count": 10650.0
+    },
+    {
+        "key": "com.digiturk.ligtv@android",
+        "co2": 0.23577499843601954,
+        "count": 5349.0
+    },
+    {
+        "key": "cookwithkushi.com",
+        "co2": 0.28060369473308394,
+        "count": 10711.0
+    },
+    {
+        "key": "pestleanalysis.com",
+        "co2": 1.321267066864333,
+        "count": 8456.0
+    },
+    {
+        "key": "247sudoku.com",
+        "co2": 0.30752088637103786,
+        "count": 15774.0
+    },
+    {
+        "key": "com.divum.MoneyControl@android",
+        "co2": 0.23135114977630852,
+        "count": 2100.0
+    },
+    {
+        "key": "com.easymobs.pregnancy@android",
+        "co2": 0.2307969765967165,
+        "count": 2267.0
+    },
+    {
+        "key": "littlethings.com",
+        "co2": 0.40122847857548666,
+        "count": 1497.0
+    },
+    {
+        "key": "parentinfluence.com",
+        "co2": 0.5119174309512748,
+        "count": 15035.0
+    },
+    {
+        "key": "pedestrian.tv",
+        "co2": 0.24986361967386736,
+        "count": 11302.0
+    },
+    {
+        "key": "roadandtrack.com",
+        "co2": 0.2782499510729888,
+        "count": 11318.0
+    },
+    {
+        "key": "sportwitness.co.uk",
+        "co2": 0.4427705595487644,
+        "count": 12092.0
+    },
+    {
+        "key": "accuweather.com",
+        "co2": 0.271292904299277,
+        "count": 90587.0
+    },
+    {
+        "key": "com.futbin@android",
+        "co2": 0.23204972492803594,
+        "count": 9933.0
+    },
+    {
+        "key": "goldderby.com",
+        "co2": 0.37659397747031714,
+        "count": 21446.0
+    },
+    {
+        "key": "quizly.co",
+        "co2": 0.319811151238809,
+        "count": 12108.0
+    },
+    {
+        "key": "rcgroups.com",
+        "co2": 0.6578237265694408,
+        "count": 14638.0
+    },
+    {
+        "key": "supercoachtalk.com",
+        "co2": 0.5425342321548864,
+        "count": 4998.0
+    },
+    {
+        "key": "barnfinds.com",
+        "co2": 1.119674304929579,
+        "count": 22952.0
+    },
+    {
+        "key": "blu-ray.com",
+        "co2": 0.5946999178978707,
+        "count": 9583.0
+    },
+    {
+        "key": "cn.hktool.android.action@android",
+        "co2": 0.23604090501538094,
+        "count": 1252.0
+    },
+    {
+        "key": "game.puzzle.woodenblockpuzzle@android",
+        "co2": 0.23909953471127057,
+        "count": 2793.0
+    },
+    {
+        "key": "au.com.mi9.jumpin.app@android",
+        "co2": 0.452554142531549,
+        "count": 4395.0
+    },
+    {
+        "key": "myfoodstory.com",
+        "co2": 0.2864587117530441,
+        "count": 10804.0
+    },
+    {
+        "key": "thespun.com",
+        "co2": 0.43021677688432935,
+        "count": 14200.0
+    },
+    {
+        "key": "timesnownews.com",
+        "co2": 0.566415771161559,
+        "count": 31677.0
+    },
+    {
+        "key": "classiccars.com",
+        "co2": 0.531363661884154,
+        "count": 24017.0
+    },
+    {
+        "key": "com.karmangames.hearts@android",
+        "co2": 0.23067034301344208,
+        "count": 2407.0
+    },
+    {
+        "key": "siasat.com",
+        "co2": 0.2894829869594668,
+        "count": 8916.0
+    },
+    {
+        "key": "thegamer.com",
+        "co2": 0.8941926265044248,
+        "count": 17732.0
+    },
+    {
+        "key": "deccanherald.com",
+        "co2": 0.7863990054953718,
+        "count": 16851.0
+    },
+    {
+        "key": "gematsu.com",
+        "co2": 0.326761775080482,
+        "count": 10925.0
+    },
+    {
+        "key": "sbsod.com",
+        "co2": 0.561086762047776,
+        "count": 32220.0
+    },
+    {
+        "key": "zkillboard.com",
+        "co2": 0.445511397127042,
+        "count": 22470.0
+    },
+    {
+        "key": "247sports.com",
+        "co2": 0.3614976131255672,
+        "count": 9414.0
+    },
+    {
+        "key": "com.karmangames.freecell@android",
+        "co2": 0.23565894906735219,
+        "count": 2242.0
+    },
+    {
+        "key": "paycalculator.com.au",
+        "co2": 0.5279512055763506,
+        "count": 33644.0
+    },
+    {
+        "key": "sheknows.com",
+        "co2": 0.40907188292979446,
+        "count": 34598.0
+    },
+    {
+        "key": "1001freefonts.com",
+        "co2": 0.5574694154533829,
+        "count": 10214.0
+    },
+    {
+        "key": "aqua-calc.com",
+        "co2": 0.2911377236030808,
+        "count": 2981.0
+    },
+    {
+        "key": "autoblog.com",
+        "co2": 0.3009615560680647,
+        "count": 7563.0
+    },
+    {
+        "key": "com.timehop@android",
+        "co2": 0.2320738853883073,
+        "count": 2092.0
+    },
+    {
+        "key": "infoplease.com",
+        "co2": 0.5256907851964142,
+        "count": 7723.0
+    },
+    {
+        "key": "surf-forecast.com",
+        "co2": 0.33271610575981064,
+        "count": 2196.0
+    },
+    {
+        "key": "viber-secure-chats-calls/id382617920@ios",
+        "co2": 0.23611067226123272,
+        "count": 9430.0
+    },
+    {
+        "key": "avforums.com",
+        "co2": 0.5069286690742276,
+        "count": 13857.0
+    },
+    {
+        "key": "com.accuweather.android@android",
+        "co2": 0.23772975817646297,
+        "count": 14508.0
+    },
+    {
+        "key": "com.appynation.puzzlepage@android",
+        "co2": 0.23305651887833229,
+        "count": 5387.0
+    },
+    {
+        "key": "com.huffingtonpost.android@android",
+        "co2": 0.22954931817474125,
+        "count": 2320.0
+    },
+    {
+        "key": "voice-online.co.uk",
+        "co2": 0.5348165982661686,
+        "count": 33698.0
+    },
+    {
+        "key": "foodnetwork.com",
+        "co2": 0.44585270183819337,
+        "count": 20372.0
+    },
+    {
+        "key": "gallery.photomanager.picturegalleryapp.imagegallery@android",
+        "co2": 0.23465414842420707,
+        "count": 2849.0
+    },
+    {
+        "key": "ikream.com",
+        "co2": 0.2929288597927839,
+        "count": 23301.0
+    },
+    {
+        "key": "anagrammer.com",
+        "co2": 0.7416087103596972,
+        "count": 3356.0
+    },
+    {
+        "key": "com.ketchapp.rider@android",
+        "co2": 0.23156883359114483,
+        "count": 2620.0
+    },
+    {
+        "key": "com.mobirix.mahjongking@android",
+        "co2": 0.23429081176992342,
+        "count": 3081.0
+    },
+    {
+        "key": "com.pakdata.QuranMajeed@android",
+        "co2": 0.2364792852449247,
+        "count": 3074.0
+    },
+    {
+        "key": "digital-photography-school.com",
+        "co2": 0.363533818252739,
+        "count": 10886.0
+    },
+    {
+        "key": "dmarge.com",
+        "co2": 0.5427513071027572,
+        "count": 3859.0
+    },
+    {
+        "key": "fordxr6turbo.com",
+        "co2": 0.544788402386115,
+        "count": 7883.0
+    },
+    {
+        "key": "newstalkzb.co.nz",
+        "co2": 0.1864025782497869,
+        "count": 24485.0
+    },
+    {
+        "key": "refinery29.com",
+        "co2": 0.5298445095002848,
+        "count": 29405.0
+    },
+    {
+        "key": "womenshealthmag.com",
+        "co2": 0.41784438130800766,
+        "count": 10369.0
+    },
+    {
+        "key": "baseball-reference.com",
+        "co2": 0.5574415183591066,
+        "count": 3530.0
+    },
+    {
+        "key": "bordermail.com.au",
+        "co2": 0.4126393008834916,
+        "count": 7301.0
+    },
+    {
+        "key": "cnet.com",
+        "co2": 0.33064145412214074,
+        "count": 4572.0
+    },
+    {
+        "key": "com.clearchannel.iheartradio.controller@android",
+        "co2": 0.2343413574437909,
+        "count": 4338.0
+    },
+    {
+        "key": "de.radio.android@android",
+        "co2": 0.23683626098512395,
+        "count": 2850.0
+    },
+    {
+        "key": "gizmodo.com.au",
+        "co2": 0.26742092010384405,
+        "count": 7364.0
+    },
+    {
+        "key": "salon.com",
+        "co2": 0.5843908708198025,
+        "count": 47740.0
+    },
+    {
+        "key": "stokesentinel.co.uk",
+        "co2": 1.0130381109564182,
+        "count": 12731.0
+    },
+    {
+        "key": "com.karmangames.solitaire@android",
+        "co2": 0.23651653857805188,
+        "count": 2175.0
+    },
+    {
+        "key": "com.zynga.boggle@android",
+        "co2": 0.23128666780301427,
+        "count": 2082.0
+    },
+    {
+        "key": "fubo.tv",
+        "co2": 0.5185086415259347,
+        "count": 54679.0
+    },
+    {
+        "key": "jagran.com",
+        "co2": 1.395555963113252,
+        "count": 22727.0
+    },
+    {
+        "key": "uk.co.aifactory.sudokufree@android",
+        "co2": 0.2474685902741017,
+        "count": 3979.0
+    },
+    {
+        "key": "warhistoryonline.com",
+        "co2": 0.5258597990299688,
+        "count": 4664.0
+    },
+    {
+        "key": "zdnet.com",
+        "co2": 0.35485049599546126,
+        "count": 5203.0
+    },
+    {
+        "key": "asianetnews.com",
+        "co2": 0.6167818534071955,
+        "count": 16742.0
+    },
+    {
+        "key": "dressupgames.com",
+        "co2": 0.6883788657304586,
+        "count": 12406.0
+    },
+    {
+        "key": "haaretz.com",
+        "co2": 1.810123666570328,
+        "count": 7643.0
+    },
+    {
+        "key": "hemmings.com",
+        "co2": 0.2756541057762289,
+        "count": 11355.0
+    },
+    {
+        "key": "pcworld.com",
+        "co2": 0.3829598723326457,
+        "count": 8098.0
+    },
+    {
+        "key": "wonderhowto.com",
+        "co2": 0.3511441594790389,
+        "count": 9815.0
+    },
+    {
+        "key": "24h.com.vn",
+        "co2": 0.6784579221072864,
+        "count": 35648.0
+    },
+    {
+        "key": "mapsofworld.com",
+        "co2": 0.4954985221828238,
+        "count": 6686.0
+    },
+    {
+        "key": "selectmedia.asia",
+        "co2": 0.259521593092874,
+        "count": 20648.0
+    },
+    {
+        "key": "tomshardware.com",
+        "co2": 0.8951166041752016,
+        "count": 3089.0
+    },
+    {
+        "key": "turtlediary.com",
+        "co2": 0.5570810632179893,
+        "count": 9635.0
+    },
+    {
+        "key": "chess.com",
+        "co2": 0.6748399484730362,
+        "count": 110976.0
+    },
+    {
+        "key": "cleveland.com",
+        "co2": 0.3044653909929488,
+        "count": 10662.0
+    },
+    {
+        "key": "com.karmangames.euchre@android",
+        "co2": 0.2330574984465134,
+        "count": 2225.0
+    },
+    {
+        "key": "delscookingtwist.com",
+        "co2": 0.28440317355784794,
+        "count": 15560.0
+    },
+    {
+        "key": "detoxinista.com",
+        "co2": 0.2894737321733548,
+        "count": 13532.0
+    },
+    {
+        "key": "gameranx.com",
+        "co2": 0.3403388382266186,
+        "count": 3186.0
+    },
+    {
+        "key": "grunge.com",
+        "co2": 0.3714332714243882,
+        "count": 14698.0
+    },
+    {
+        "key": "minecraftforge.net",
+        "co2": 0.2621017781507641,
+        "count": 11818.0
+    },
+    {
+        "key": "tastesoflizzyt.com",
+        "co2": 0.2866427757386506,
+        "count": 10487.0
+    },
+    {
+        "key": "toofab.com",
+        "co2": 0.23949774557368256,
+        "count": 2137.0
+    },
+    {
+        "key": "top5.com",
+        "co2": 0.6132690069872813,
+        "count": 9055.0
+    },
+    {
+        "key": "com.hyperionics.avar@android",
+        "co2": 0.23206160925608985,
+        "count": 1480.0
+    },
+    {
+        "key": "com.toi.reader.activities@android",
+        "co2": 0.2343348266289357,
+        "count": 10723.0
+    },
+    {
+        "key": "dsogaming.com",
+        "co2": 0.9690221933828327,
+        "count": 9822.0
+    },
+    {
+        "key": "fstoppers.com",
+        "co2": 0.6859331823039516,
+        "count": 11934.0
+    },
+    {
+        "key": "gtplanet.net",
+        "co2": 0.6075985124534439,
+        "count": 32616.0
+    },
+    {
+        "key": "mid-day.com",
+        "co2": 0.7115105750187898,
+        "count": 3016.0
+    },
+    {
+        "key": "nymag.com",
+        "co2": 0.2937917450130216,
+        "count": 12307.0
+    },
+    {
+        "key": "thecountrycook.net",
+        "co2": 0.281407211771847,
+        "count": 4506.0
+    },
+    {
+        "key": "com.textra@android",
+        "co2": 0.23207960872243566,
+        "count": 2907.0
+    },
+    {
+        "key": "dogtime.com",
+        "co2": 0.7936449284749747,
+        "count": 205415.0
+    },
+    {
+        "key": "howstuffworks.com",
+        "co2": 0.35300613177807755,
+        "count": 4608.0
+    },
+    {
+        "key": "indiamart.com",
+        "co2": 0.6026551900335141,
+        "count": 8133.0
+    },
+    {
+        "key": "segmentnext.com",
+        "co2": 0.7428080936641233,
+        "count": 12608.0
+    },
+    {
+        "key": "com.appynation.wbcw@android",
+        "co2": 0.2440550143294705,
+        "count": 1416.0
+    },
+    {
+        "key": "dailytelegraph.com.au",
+        "co2": 0.2820423871943533,
+        "count": 403407.0
+    },
+    {
+        "key": "ebay.com",
+        "co2": 0.2569180677761955,
+        "count": 15872.0
+    },
+    {
+        "key": "islcollective.com",
+        "co2": 0.6817168191257826,
+        "count": 5137.0
+    },
+    {
+        "key": "localhost",
+        "co2": 0.2667609351549643,
+        "count": 49622.0
+    },
+    {
+        "key": "myhealthgazette.com",
+        "co2": 0.35591887390939186,
+        "count": 4239.0
+    },
+    {
+        "key": "astrology.com",
+        "co2": 0.49979040389957075,
+        "count": 3131.0
+    },
+    {
+        "key": "housebeautiful.com",
+        "co2": 0.2747768083398501,
+        "count": 10901.0
+    },
+    {
+        "key": "parentsdome.com",
+        "co2": 0.9625817077762336,
+        "count": 340935.0
+    },
+    {
+        "key": "spoilertv.com",
+        "co2": 0.6308836348000766,
+        "count": 5731.0
+    },
+    {
+        "key": "tvbsmh.com",
+        "co2": 0.23298876656970047,
+        "count": 1242.0
+    },
+    {
+        "key": "com.coolmango.sudokufun@android",
+        "co2": 0.23357872857387826,
+        "count": 2777.0
+    },
+    {
+        "key": "gay-sejour.com",
+        "co2": 0.24464522877551126,
+        "count": 17792.0
+    },
+    {
+        "key": "sayingimages.com",
+        "co2": 0.2770175899903156,
+        "count": 9880.0
+    },
+    {
+        "key": "ytravelblog.com",
+        "co2": 0.2985145534452996,
+        "count": 9463.0
+    },
+    {
+        "key": "mbappgewtgobsgiztgobvge888888.com",
+        "co2": 0.24394256760703376,
+        "count": 8049.0
+    },
+    {
+        "key": "moneycontrol.com",
+        "co2": 0.2926951981242499,
+        "count": 8034.0
+    },
+    {
+        "key": "ball-blast/id1383187127@ios",
+        "co2": 0.23986515315921095,
+        "count": 1298.0
+    },
+    {
+        "key": "com.commsource.beautyplus@android",
+        "co2": 0.23879371951521144,
+        "count": 2773.0
+    },
+    {
+        "key": "com.phyora.apps.reddit_now@android",
+        "co2": 0.23161862807384112,
+        "count": 2665.0
+    },
+    {
+        "key": "com.wte.view@android",
+        "co2": 0.23059370910225568,
+        "count": 1561.0
+    },
+    {
+        "key": "gourmettraveller.com.au",
+        "co2": 0.32405962315935527,
+        "count": 34285.0
+    },
+    {
+        "key": "hollywoodlife.com",
+        "co2": 0.3499918269063205,
+        "count": 10466.0
+    },
+    {
+        "key": "nba.com",
+        "co2": 0.37125858823231583,
+        "count": 6502.0
+    },
+    {
+        "key": "notalwaysright.com",
+        "co2": 0.5456560951139791,
+        "count": 4616.0
+    },
+    {
+        "key": "wholefully.com",
+        "co2": 0.2865786787636034,
+        "count": 10368.0
+    },
+    {
+        "key": "braingle.com",
+        "co2": 0.5970768022678155,
+        "count": 4060.0
+    },
+    {
+        "key": "com.nzherald.activities@android",
+        "co2": 0.23095639592864434,
+        "count": 2291.0
+    },
+    {
+        "key": "com.quizlet.quizletandroid@android",
+        "co2": 0.23400996482488653,
+        "count": 1967.0
+    },
+    {
+        "key": "com.razzlepuzzles.fillins@android",
+        "co2": 0.23466228395029523,
+        "count": 2741.0
+    },
+    {
+        "key": "philstar.com",
+        "co2": 0.3287210924976459,
+        "count": 10516.0
+    },
+    {
+        "key": "themag.co.uk",
+        "co2": 1.4625915969588632,
+        "count": 14235.0
+    },
+    {
+        "key": "theroyalforums.com",
+        "co2": 0.27309144072120367,
+        "count": 5398.0
+    },
+    {
+        "key": "com.easybrain.solitaire.klondike.free@android",
+        "co2": 0.23357322064407302,
+        "count": 1801.0
+    },
+    {
+        "key": "com.fitnow.loseit@android",
+        "co2": 0.23108092521609344,
+        "count": 1011.0
+    },
+    {
+        "key": "giantbomb.com",
+        "co2": 0.5789433617274143,
+        "count": 3837.0
+    },
+    {
+        "key": "hearthstonetopdecks.com",
+        "co2": 0.8437836335859543,
+        "count": 13875.0
+    },
+    {
+        "key": "online-tech-tips.com",
+        "co2": 0.6029451126576957,
+        "count": 9859.0
+    },
+    {
+        "key": "bangkokpost.com",
+        "co2": 1.090307535795211,
+        "count": 1509.0
+    },
+    {
+        "key": "com.tksolution.einkaufszettelmitspracheingabe@android",
+        "co2": 0.22796460732203822,
+        "count": 1651.0
+    },
+    {
+        "key": "com.wordreference@android",
+        "co2": 0.2331705346653781,
+        "count": 1110.0
+    },
+    {
+        "key": "nasdaq.com",
+        "co2": 0.5151986413137731,
+        "count": 5189.0
+    },
+    {
+        "key": "com.gamebility.onet@android",
+        "co2": 0.2338432792857492,
+        "count": 1958.0
+    },
+    {
+        "key": "heraldsun.com.au",
+        "co2": 0.24927512081218098,
+        "count": 760903.0
+    },
+    {
+        "key": "ninemsn.com.au",
+        "co2": 0.26888610362629883,
+        "count": 4535.0
+    },
+    {
+        "key": "riddles.com",
+        "co2": 0.5279208215151455,
+        "count": 6066.0
+    },
+    {
+        "key": "cdkitchen.com",
+        "co2": 1.5392661787447146,
+        "count": 13589.0
+    },
+    {
+        "key": "com.etermax.preguntados.lite@android",
+        "co2": 0.231351204290731,
+        "count": 1583.0
+    },
+    {
+        "key": "com.littleengine.wordpal@android",
+        "co2": 0.23555078718376887,
+        "count": 3089.0
+    },
+    {
+        "key": "movieweb.com",
+        "co2": 0.641343431873655,
+        "count": 13866.0
+    },
+    {
+        "key": "hrtwarming.com",
+        "co2": 0.4804446995153,
+        "count": 1544.0
+    },
+    {
+        "key": "shareably.net",
+        "co2": 0.47704648161250146,
+        "count": 18268.0
+    },
+    {
+        "key": "streema.com",
+        "co2": 0.2754855739540573,
+        "count": 18626.0
+    },
+    {
+        "key": "zoo.com",
+        "co2": 0.35842636373923314,
+        "count": 10715.0
+    },
+    {
+        "key": "com.csnmedia.android.bg@android",
+        "co2": 0.23104327777987102,
+        "count": 1136.0
+    },
+    {
+        "key": "com.mobilityware.MahjongSolitaire@android",
+        "co2": 0.23380591666151018,
+        "count": 2169.0
+    },
+    {
+        "key": "ekathimerini.com",
+        "co2": 0.31626623057764974,
+        "count": 7311.0
+    },
+    {
+        "key": "homestolove.com.au",
+        "co2": 0.326464778666937,
+        "count": 1353.0
+    },
+    {
+        "key": "mkyong.com",
+        "co2": 0.5887028675145438,
+        "count": 7342.0
+    },
+    {
+        "key": "mooglyblog.com",
+        "co2": 0.31300618023874854,
+        "count": 5598.0
+    },
+    {
+        "key": "songmeanings.com",
+        "co2": 0.24334054724862603,
+        "count": 2036.0
+    },
+    {
+        "key": "worldofbuzz.com",
+        "co2": 0.6587037900497696,
+        "count": 10021.0
+    },
+    {
+        "key": "ynetnews.com",
+        "co2": 0.6619744944575349,
+        "count": 3360.0
+    },
+    {
+        "key": "com.brucemax.boxintervals@android",
+        "co2": 0.2216093529529771,
+        "count": 1386.0
+    },
+    {
+        "key": "fm.player@android",
+        "co2": 0.23006408182502294,
+        "count": 6448.0
+    },
+    {
+        "key": "inkedmag.com",
+        "co2": 0.4051865795328377,
+        "count": 6210.0
+    },
+    {
+        "key": "mtbr.com",
+        "co2": 0.6486623111431167,
+        "count": 23384.0
+    },
+    {
+        "key": "outlookindia.com",
+        "co2": 0.6086699524706207,
+        "count": 1115.0
+    },
+    {
+        "key": "bubbles.pop.power@android",
+        "co2": 0.23227373502736062,
+        "count": 2161.0
+    },
+    {
+        "key": "com.gsn.android.tripeaks@android",
+        "co2": 0.2326797388049512,
+        "count": 1173.0
+    },
+    {
+        "key": "oneacross.com",
+        "co2": 0.3948116242595155,
+        "count": 7699.0
+    },
+    {
+        "key": "www.nj.com",
+        "co2": 0.3039634896554974,
+        "count": 6405.0
+    },
+    {
+        "key": "boldsky.com",
+        "co2": 0.21376819299807004,
+        "count": 18858.0
+    },
+    {
+        "key": "carls-sims-4-guide.com",
+        "co2": 0.5670351897915262,
+        "count": 9866.0
+    },
+    {
+        "key": "slashfilm.com",
+        "co2": 0.39146169677870796,
+        "count": 20241.0
+    },
+    {
+        "key": "br.com.tapps.logicpic@android",
+        "co2": 0.23118485010276923,
+        "count": 1212.0
+    },
+    {
+        "key": "collider.com",
+        "co2": 0.9682528128428399,
+        "count": 4301.0
+    },
+    {
+        "key": "com.goldtouch.ynet@android",
+        "co2": 0.2301444483841871,
+        "count": 2848.0
+    },
+    {
+        "key": "fivethirtyeight.com",
+        "co2": 0.25577740947803385,
+        "count": 4338.0
+    },
+    {
+        "key": "gkfooddiary.com",
+        "co2": 0.2850671197271874,
+        "count": 4724.0
+    },
+    {
+        "key": "shockwave.com",
+        "co2": 0.2643517007539984,
+        "count": 12411.0
+    },
+    {
+        "key": "thefedupfoodie.com",
+        "co2": 0.28603489313757763,
+        "count": 8054.0
+    },
+    {
+        "key": "akamaihd.net",
+        "co2": 0.2284681875210008,
+        "count": 25040.0
+    },
+    {
+        "key": "authoritytattoo.com",
+        "co2": 0.28908875717825794,
+        "count": 7858.0
+    },
+    {
+        "key": "com.firecrackersw.wordbreaker@android",
+        "co2": 0.23180180457783253,
+        "count": 1666.0
+    },
+    {
+        "key": "com.thecarousell.Carousell@android",
+        "co2": 0.23015677256690795,
+        "count": 1117.0
+    },
+    {
+        "key": "expeditionportal.com",
+        "co2": 0.2658255895532068,
+        "count": 7123.0
+    },
+    {
+        "key": "glam.com",
+        "co2": 0.38368193331266076,
+        "count": 27273.0
+    },
+    {
+        "key": "movetv.com",
+        "co2": 0.462853451405996,
+        "count": 109316.0
+    },
+    {
+        "key": "newcastleherald.com.au",
+        "co2": 0.4109741642310059,
+        "count": 1719.0
+    },
+    {
+        "key": "wokandskillet.com",
+        "co2": 0.2856165036924495,
+        "count": 7197.0
+    },
+    {
+        "key": "allfreesewing.com",
+        "co2": 0.8223726068970035,
+        "count": 3241.0
+    },
+    {
+        "key": "com.ahoygames.okey@android",
+        "co2": 0.2305767871614259,
+        "count": 1163.0
+    },
+    {
+        "key": "latimes.com",
+        "co2": 0.2741587654619627,
+        "count": 24176.0
+    },
+    {
+        "key": "nextbigfuture.com",
+        "co2": 0.309541935842247,
+        "count": 1348.0
+    },
+    {
+        "key": "scrabblewordfinder.org",
+        "co2": 0.24808823258848953,
+        "count": 13261.0
+    },
+    {
+        "key": "skinnyms.com",
+        "co2": 0.28548956408470355,
+        "count": 8992.0
+    },
+    {
+        "key": "vice.com",
+        "co2": 0.5248474352230488,
+        "count": 12384.0
+    },
+    {
+        "key": "mbappgiwwg33nfztgy2lhnb2heylemfzdendgojswk888.com",
+        "co2": 0.21652685264391291,
+        "count": 4975.0
+    },
+    {
+        "key": "stevethebartender.com.au",
+        "co2": 0.7514412797343164,
+        "count": 1733.0
+    },
+    {
+        "key": "com.cri.archive@android",
+        "co2": 0.23130984031289084,
+        "count": 1054.0
+    },
+    {
+        "key": "com.tbig.playerprotrial@android",
+        "co2": 0.23853360331197399,
+        "count": 1110.0
+    },
+    {
+        "key": "com.zynga.crosswordswithfriends@android",
+        "co2": 0.23408216387120862,
+        "count": 1969.0
+    },
+    {
+        "key": "draziw.karavan.sudoku@android",
+        "co2": 0.22367414401310684,
+        "count": 1641.0
+    },
+    {
+        "key": "newarena.com",
+        "co2": 1.05272397332534,
+        "count": 1343.0
+    },
+    {
+        "key": "saveur.com",
+        "co2": 0.2710900380168693,
+        "count": 4881.0
+    },
+    {
+        "key": "thekitchn.com",
+        "co2": 0.47006270581137,
+        "count": 11426.0
+    },
+    {
+        "key": "com.acidcousins.fdunk@android",
+        "co2": 0.2345578557339224,
+        "count": 3282.0
+    },
+    {
+        "key": "com.talkatone.android@android",
+        "co2": 0.2248991213757521,
+        "count": 1383.0
+    },
+    {
+        "key": "cricketweb.net",
+        "co2": 0.6247907349418048,
+        "count": 3583.0
+    },
+    {
+        "key": "dumbingofage.com",
+        "co2": 0.31947825409370917,
+        "count": 26659.0
+    },
+    {
+        "key": "net.relaxio.babysleep@android",
+        "co2": 0.2312411837815872,
+        "count": 2479.0
+    },
+    {
+        "key": "observer.com",
+        "co2": 0.3081932041032288,
+        "count": 3433.0
+    },
+    {
+        "key": "picresize.com",
+        "co2": 1.1157402945154138,
+        "count": 4650.0
+    },
+    {
+        "key": "tenforums.com",
+        "co2": 0.24868279735040377,
+        "count": 2662.0
+    },
+    {
+        "key": "thefreshloaf.com",
+        "co2": 0.5087812258751556,
+        "count": 7285.0
+    },
+    {
+        "key": "wmagazine.com",
+        "co2": 0.2703753111091134,
+        "count": 9976.0
+    },
+    {
+        "key": "com.differencetenderwhite.skirt@android",
+        "co2": 0.2356238455156554,
+        "count": 1382.0
+    },
+    {
+        "key": "goulburnpost.com.au",
+        "co2": 0.42287743963535235,
+        "count": 2483.0
+    },
+    {
+        "key": "greetingsisland.com",
+        "co2": 0.2926846694170555,
+        "count": 7450.0
+    },
+    {
+        "key": "newsone.com",
+        "co2": 0.41326405459271537,
+        "count": 1200.0
+    },
+    {
+        "key": "radio.net",
+        "co2": 0.49692660804710387,
+        "count": 3675.0
+    },
+    {
+        "key": "super_xv.live@android",
+        "co2": 0.2385999693311966,
+        "count": 3650.0
+    },
+    {
+        "key": "the-gadgeteer.com",
+        "co2": 0.9019256724813742,
+        "count": 4949.0
+    },
+    {
+        "key": "wunderground.com",
+        "co2": 0.25897424204474206,
+        "count": 20660.0
+    },
+    {
+        "key": "247mirror.com",
+        "co2": 0.4097262718948138,
+        "count": 7823.0
+    },
+    {
+        "key": "agtrader.com.au",
+        "co2": 0.2463471945033061,
+        "count": 5245.0
+    },
+    {
+        "key": "com.pt.wshhp@android",
+        "co2": 0.40020111104624095,
+        "count": 3636.0
+    },
+    {
+        "key": "favequilts.com",
+        "co2": 1.0041397653550317,
+        "count": 4945.0
+    },
+    {
+        "key": "irishmirror.ie",
+        "co2": 0.764533661423411,
+        "count": 9874.0
+    },
+    {
+        "key": "lequipe.fr@android",
+        "co2": 0.23178910084913776,
+        "count": 2170.0
+    },
+    {
+        "key": "brandsoftheworld.com",
+        "co2": 0.265680330223381,
+        "count": 9658.0
+    },
+    {
+        "key": "eliteprospects.com",
+        "co2": 0.7708103060015454,
+        "count": 9451.0
+    },
+    {
+        "key": "empireofthekop.com",
+        "co2": 0.3186706914290772,
+        "count": 2695.0
+    },
+    {
+        "key": "google.com",
+        "co2": 0.2627475823738126,
+        "count": 5023.0
+    },
+    {
+        "key": "heroichollywood.com",
+        "co2": 0.2811253422919403,
+        "count": 11929.0
+    },
+    {
+        "key": "kinderart.com",
+        "co2": 0.2946565497324601,
+        "count": 8309.0
+    },
+    {
+        "key": "outnewsglobal.com",
+        "co2": 0.27785798236765713,
+        "count": 12085.0
+    },
+    {
+        "key": "smogon.com",
+        "co2": 0.307074209474809,
+        "count": 4498.0
+    },
+    {
+        "key": "trovit.com",
+        "co2": 0.24674980687776035,
+        "count": 4655.0
+    },
+    {
+        "key": "countrymusicnation.com",
+        "co2": 0.46817631746988786,
+        "count": 10552.0
+    },
+    {
+        "key": "food.com",
+        "co2": 0.28775855342805695,
+        "count": 4080.0
+    },
+    {
+        "key": "free.reddit.news@android",
+        "co2": 0.2289410115728175,
+        "count": 3334.0
+    },
+    {
+        "key": "mangalam.com",
+        "co2": 0.6736880147695654,
+        "count": 5580.0
+    },
+    {
+        "key": "portnews.com.au",
+        "co2": 0.41959415544144574,
+        "count": 3561.0
+    },
+    {
+        "key": "ranger-forums.com",
+        "co2": 0.3370492387232296,
+        "count": 4251.0
+    },
+    {
+        "key": "starsunfolded.com",
+        "co2": 1.020182878191375,
+        "count": 15630.0
+    },
+    {
+        "key": "userbenchmark.com",
+        "co2": 0.254065871249443,
+        "count": 10256.0
+    },
+    {
+        "key": "xboxachievements.com",
+        "co2": 0.3208501089820542,
+        "count": 2055.0
+    },
+    {
+        "key": "yupptv.com",
+        "co2": 0.2926684421635644,
+        "count": 2620.0
+    },
+    {
+        "key": "9bills.co.uk",
+        "co2": 0.28052399667082545,
+        "count": 1875.0
+    },
+    {
+        "key": "adtelligent.com",
+        "co2": 0.25970788472118406,
+        "count": 5905.0
+    },
+    {
+        "key": "chron.com",
+        "co2": 0.5080348159257086,
+        "count": 22455.0
+    },
+    {
+        "key": "com.scannerradio@android",
+        "co2": 0.22533654269287093,
+        "count": 2923.0
+    },
+    {
+        "key": "favecrafts.com",
+        "co2": 0.7932805140759276,
+        "count": 1931.0
+    },
+    {
+        "key": "lifehacker.com.au",
+        "co2": 0.25753288638845817,
+        "count": 3332.0
+    },
+    {
+        "key": "mother.ly",
+        "co2": 0.298917706234267,
+        "count": 19698.0
+    },
+    {
+        "key": "pythonforbeginners.com",
+        "co2": 0.49408050692413424,
+        "count": 2983.0
+    },
+    {
+        "key": "rotinrice.com",
+        "co2": 0.31083788619480324,
+        "count": 6423.0
+    },
+    {
+        "key": "thriftylittlemom.com",
+        "co2": 0.2802204220681424,
+        "count": 8441.0
+    },
+    {
+        "key": "topg.org",
+        "co2": 0.25145660111430274,
+        "count": 5557.0
+    },
+    {
+        "key": "astrologyanswers.com",
+        "co2": 0.48691196419977145,
+        "count": 5536.0
+    },
+    {
+        "key": "autocar.co.uk",
+        "co2": 0.3097425031933832,
+        "count": 2008.0
+    },
+    {
+        "key": "browneyedbaker.com",
+        "co2": 0.27708536748663165,
+        "count": 7005.0
+    },
+    {
+        "key": "insider.com",
+        "co2": 0.26334085566142285,
+        "count": 6192.0
+    },
+    {
+        "key": "kothiyavunu.com",
+        "co2": 0.2918825183792029,
+        "count": 5285.0
+    },
+    {
+        "key": "loudersound.com",
+        "co2": 0.904876197957858,
+        "count": 2713.0
+    },
+    {
+        "key": "manilatimes.net",
+        "co2": 0.5747468040514331,
+        "count": 3014.0
+    },
+    {
+        "key": "musicfeeds.com.au",
+        "co2": 0.6803344912802299,
+        "count": 22249.0
+    },
+    {
+        "key": "cardgamespidersolitaire.com",
+        "co2": 0.3262711889950401,
+        "count": 13800.0
+    },
+    {
+        "key": "com.opensooq.OpenSooq@android",
+        "co2": 0.2567319449530174,
+        "count": 1621.0
+    },
+    {
+        "key": "hunker.com",
+        "co2": 0.5190392960150584,
+        "count": 5977.0
+    },
+    {
+        "key": "nasioc.com",
+        "co2": 0.2508245721515756,
+        "count": 1781.0
+    },
+    {
+        "key": "outlook.com",
+        "co2": 0.23616396579564075,
+        "count": 2798.0
+    },
+    {
+        "key": "rappler.com",
+        "co2": 1.0992307306571476,
+        "count": 7482.0
+    },
+    {
+        "key": "strategywiki.org",
+        "co2": 0.35583283736060406,
+        "count": 2181.0
+    },
+    {
+        "key": "uniteuk1.com",
+        "co2": 0.2910539159733637,
+        "count": 7492.0
+    },
+    {
+        "key": "vietworldkitchen.com",
+        "co2": 0.30459444255185575,
+        "count": 4452.0
+    },
+    {
+        "key": "cheezburger.com",
+        "co2": 0.45878307185702477,
+        "count": 2996.0
+    },
+    {
+        "key": "com.outfit7.mytalkingtomfriends@android",
+        "co2": 0.23500463782516645,
+        "count": 3038.0
+    },
+    {
+        "key": "com.pandoomobile.GemsJourney@android",
+        "co2": 0.2406614617779702,
+        "count": 1132.0
+    },
+    {
+        "key": "heraldscotland.com",
+        "co2": 0.42686617570504937,
+        "count": 10909.0
+    },
+    {
+        "key": "hoopsrumors.com",
+        "co2": 0.27195782844446853,
+        "count": 1972.0
+    },
+    {
+        "key": "mazda3forums.com",
+        "co2": 0.6515729347598138,
+        "count": 4183.0
+    },
+    {
+        "key": "mazda6club.com",
+        "co2": 0.6491782110058617,
+        "count": 4709.0
+    },
+    {
+        "key": "nissanpatrol.com.au",
+        "co2": 0.4324743375537498,
+        "count": 5618.0
+    },
+    {
+        "key": "philo.com",
+        "co2": 0.46312743888791114,
+        "count": 84804.0
+    },
+    {
+        "key": "southcoastregister.com.au",
+        "co2": 0.4246193075295069,
+        "count": 2664.0
+    },
+    {
+        "key": "tasteofcinema.com",
+        "co2": 0.5946579412449834,
+        "count": 5401.0
+    },
+    {
+        "key": "thatslife.com.au",
+        "co2": 0.31063984286397345,
+        "count": 1300.0
+    },
+    {
+        "key": "batemansbaypost.com.au",
+        "co2": 0.42083903828153807,
+        "count": 1231.0
+    },
+    {
+        "key": "blizzardwatch.com",
+        "co2": 0.7517672720618567,
+        "count": 5697.0
+    },
+    {
+        "key": "com.h8games.helixjump@android",
+        "co2": 0.24022478419336074,
+        "count": 3848.0
+    },
+    {
+        "key": "guru3d.com",
+        "co2": 0.3360991857177448,
+        "count": 2979.0
+    },
+    {
+        "key": "knittingparadise.com",
+        "co2": 0.6795713391651678,
+        "count": 6954.0
+    },
+    {
+        "key": "marcandangel.com",
+        "co2": 0.3422281839738225,
+        "count": 8051.0
+    },
+    {
+        "key": "uk.co.aifactory.rrfree@android",
+        "co2": 0.23280888851270395,
+        "count": 1190.0
+    },
+    {
+        "key": "worldsurfleague.com",
+        "co2": 0.4409302731683661,
+        "count": 155295.0
+    },
+    {
+        "key": "com.gamecircus.CoinDozerJackpot@android",
+        "co2": 0.2297955398712982,
+        "count": 2913.0
+    },
+    {
+        "key": "dbltap.com",
+        "co2": 0.7136461275319087,
+        "count": 4910.0
+    },
+    {
+        "key": "gumtree.co.za",
+        "co2": 0.30041425052297227,
+        "count": 3032.0
+    },
+    {
+        "key": "belloflostsouls.net",
+        "co2": 0.5476589171378843,
+        "count": 22986.0
+    },
+    {
+        "key": "com.karmangames.spider@android",
+        "co2": 0.23779797048966606,
+        "count": 1402.0
+    },
+    {
+        "key": "com.meitu.meiyancamera@android",
+        "co2": 0.24275228015861058,
+        "count": 2659.0
+    },
+    {
+        "key": "com.scores365@android",
+        "co2": 0.23446296916365153,
+        "count": 3813.0
+    },
+    {
+        "key": "dvdsreleasedates.com",
+        "co2": 0.4217806534161989,
+        "count": 3713.0
+    },
+    {
+        "key": "gulte.com",
+        "co2": 0.7902974317834226,
+        "count": 9898.0
+    },
+    {
+        "key": "ikeahackers.net",
+        "co2": 0.2964804062471734,
+        "count": 8281.0
+    },
+    {
+        "key": "propertyguru.com.sg",
+        "co2": 0.2561179688770493,
+        "count": 1757.0
+    },
+    {
+        "key": "sport-fitness-advisor.com",
+        "co2": 0.28729032934675075,
+        "count": 5919.0
+    },
+    {
+        "key": "sunderlandecho.com",
+        "co2": 1.1933068271040932,
+        "count": 8405.0
+    },
+    {
+        "key": "uk.co.aifactory.spadesfree@android",
+        "co2": 0.22731049513157414,
+        "count": 1264.0
+    },
+    {
+        "key": "12up.com",
+        "co2": 0.7381636390878885,
+        "count": 11825.0
+    },
+    {
+        "key": "com.shotzoom.golfshot2@android",
+        "co2": 0.2341353321818337,
+        "count": 1830.0
+    },
+    {
+        "key": "cracked.com",
+        "co2": 0.595827967184775,
+        "count": 1272.0
+    },
+    {
+        "key": "imgur.com",
+        "co2": 0.4100768942906359,
+        "count": 27523.0
+    },
+    {
+        "key": "inquirer.net",
+        "co2": 0.4739617178216861,
+        "count": 5355.0
+    },
+    {
+        "key": "malaysianchinesekitchen.com",
+        "co2": 0.2842084691773176,
+        "count": 2527.0
+    },
+    {
+        "key": "modhub.us",
+        "co2": 0.5691512564999933,
+        "count": 2825.0
+    },
+    {
+        "key": "mylespaul.com",
+        "co2": 0.33785959978593505,
+        "count": 4387.0
+    },
+    {
+        "key": "politico.com",
+        "co2": 0.2799931235011306,
+        "count": 1146.0
+    },
+    {
+        "key": "quotes.net",
+        "co2": 0.2754102461586879,
+        "count": 4504.0
+    },
+    {
+        "key": "solitairetime.com",
+        "co2": 0.32083165586314416,
+        "count": 5862.0
+    },
+    {
+        "key": "90min.com",
+        "co2": 0.7266302642642798,
+        "count": 27181.0
+    },
+    {
+        "key": "com.sega.sonicdash@android",
+        "co2": 0.2343756921919953,
+        "count": 1895.0
+    },
+    {
+        "key": "cookrepublic.com",
+        "co2": 0.29687491162097307,
+        "count": 7323.0
+    },
+    {
+        "key": "craftbits.com",
+        "co2": 0.3045416426552572,
+        "count": 3821.0
+    },
+    {
+        "key": "dailypost.co.uk",
+        "co2": 0.8566402069360366,
+        "count": 8728.0
+    },
+    {
+        "key": "facty.com",
+        "co2": 0.3113146040204467,
+        "count": 8862.0
+    },
+    {
+        "key": "holiday-weather.com",
+        "co2": 0.5129412814204033,
+        "count": 5247.0
+    },
+    {
+        "key": "joe.co.uk",
+        "co2": 0.35466523348310264,
+        "count": 7485.0
+    },
+    {
+        "key": "makeuseof.com",
+        "co2": 0.8392867525085751,
+        "count": 4929.0
+    },
+    {
+        "key": "powerpyx.com",
+        "co2": 0.4090731941238486,
+        "count": 26908.0
+    },
+    {
+        "key": "rpgsite.net",
+        "co2": 0.4708896368047096,
+        "count": 14362.0
+    },
+    {
+        "key": "versus.com",
+        "co2": 0.33169502878123736,
+        "count": 5452.0
+    },
+    {
+        "key": "yummytummyaarthi.com",
+        "co2": 0.28759106067408197,
+        "count": 5787.0
+    },
+    {
+        "key": "aaj-tak/id493319791@ios",
+        "co2": 0.2405380237626194,
+        "count": 2057.0
+    },
+    {
+        "key": "azcentral.com",
+        "co2": 0.2909854039164931,
+        "count": 4407.0
+    },
+    {
+        "key": "blockudoku-blocks-puzzle/id1452227871@ios",
+        "co2": 0.2365755992189744,
+        "count": 2826.0
+    },
+    {
+        "key": "com.kathleenOswald.solitaireGooglePlay@android",
+        "co2": 0.23412794558055275,
+        "count": 2608.0
+    },
+    {
+        "key": "com.soodexlabs.sudoku2@android",
+        "co2": 0.23803883203518036,
+        "count": 1204.0
+    },
+    {
+        "key": "com.tesseractmobile.solitairemulti@android",
+        "co2": 0.22487095556394143,
+        "count": 1418.0
+    },
+    {
+        "key": "grandprix247.com",
+        "co2": 0.4111794978083192,
+        "count": 4587.0
+    },
+    {
+        "key": "kiplinger.com",
+        "co2": 0.9186491351255541,
+        "count": 3405.0
+    },
+    {
+        "key": "lovewhatmatters.com",
+        "co2": 0.7207945704983976,
+        "count": 12428.0
+    },
+    {
+        "key": "songfacts.com",
+        "co2": 0.6096153651586987,
+        "count": 11119.0
+    },
+    {
+        "key": "com.imo.android.imoimbeta@android",
+        "co2": 0.24119015218947293,
+        "count": 3033.0
+    },
+    {
+        "key": "com.outfit7.mytalkingtomfree@android",
+        "co2": 0.23719742938649546,
+        "count": 1406.0
+    },
+    {
+        "key": "dailyfitnesstip.com",
+        "co2": 0.883617880505171,
+        "count": 11596.0
+    },
+    {
+        "key": "realhousemoms.com",
+        "co2": 0.28512965264842727,
+        "count": 5051.0
+    },
+    {
+        "key": "travelmamas.com",
+        "co2": 0.2869427064699687,
+        "count": 3736.0
+    },
+    {
+        "key": "vintag.es",
+        "co2": 0.4716661437092417,
+        "count": 4277.0
+    },
+    {
+        "key": "craftymorning.com",
+        "co2": 0.30702168827146575,
+        "count": 9057.0
+    },
+    {
+        "key": "gujaratsamachar.com",
+        "co2": 0.6466054984870322,
+        "count": 1220.0
+    },
+    {
+        "key": "hola.com",
+        "co2": 1.0566714738045468,
+        "count": 4334.0
+    },
+    {
+        "key": "manningrivertimes.com.au",
+        "co2": 0.43012362593637254,
+        "count": 2578.0
+    },
+    {
+        "key": "mtv.com",
+        "co2": 0.6860011690161316,
+        "count": 2991.0
+    },
+    {
+        "key": "nesn.com",
+        "co2": 0.41167777977792963,
+        "count": 2366.0
+    },
+    {
+        "key": "plex.tv",
+        "co2": 1.0956471760619955,
+        "count": 1975.0
+    },
+    {
+        "key": "techlicious.com",
+        "co2": 0.624268665861374,
+        "count": 3698.0
+    },
+    {
+        "key": "topspeed.com",
+        "co2": 0.7751511157771768,
+        "count": 4133.0
+    },
+    {
+        "key": "allpeoplequilt.com",
+        "co2": 0.287303281168884,
+        "count": 3412.0
+    },
+    {
+        "key": "com.app.cricketapp@android",
+        "co2": 0.22952134756644604,
+        "count": 1701.0
+    },
+    {
+        "key": "com.ivuu@android",
+        "co2": 0.2289540218659183,
+        "count": 1104.0
+    },
+    {
+        "key": "com.leftover.CoinDozer@android",
+        "co2": 0.23294194848159436,
+        "count": 1964.0
+    },
+    {
+        "key": "homesandgardens.com",
+        "co2": 0.9519325335961069,
+        "count": 5048.0
+    },
+    {
+        "key": "howtogeek.com",
+        "co2": 0.49039084608813427,
+        "count": 2389.0
+    },
+    {
+        "key": "marieclaire.com.au",
+        "co2": 0.3740137213696278,
+        "count": 27729.0
+    },
+    {
+        "key": "minq.com",
+        "co2": 0.321102099134796,
+        "count": 57326.0
+    },
+    {
+        "key": "punchng.com",
+        "co2": 1.622475262673653,
+        "count": 3570.0
+    },
+    {
+        "key": "quranicnames.com",
+        "co2": 1.4355444914449778,
+        "count": 4371.0
+    },
+    {
+        "key": "shutterbean.com",
+        "co2": 0.2852652152210999,
+        "count": 2330.0
+    },
+    {
+        "key": "bloodyelbow.com",
+        "co2": 0.5058072322954341,
+        "count": 6196.0
+    },
+    {
+        "key": "fujirumors.com",
+        "co2": 0.6015601372630629,
+        "count": 3271.0
+    },
+    {
+        "key": "heatnation.com",
+        "co2": 0.3995502718434161,
+        "count": 1490.0
+    },
+    {
+        "key": "ibreatheimhungry.com",
+        "co2": 0.2860134312220999,
+        "count": 4396.0
+    },
+    {
+        "key": "ir.remote.smg.tv@android",
+        "co2": 0.23207953427721129,
+        "count": 1258.0
+    },
+    {
+        "key": "journeyranger.com",
+        "co2": 0.5091626904563104,
+        "count": 1883.0
+    },
+    {
+        "key": "letsrun.com",
+        "co2": 0.8262861179500168,
+        "count": 15451.0
+    },
+    {
+        "key": "lexicanum.com",
+        "co2": 0.31455143969900906,
+        "count": 13564.0
+    },
+    {
+        "key": "nhl.com",
+        "co2": 0.25422336845485377,
+        "count": 11768.0
+    },
+    {
+        "key": "petsreporter.com",
+        "co2": 0.47512092453351773,
+        "count": 6424.0
+    },
+    {
+        "key": "pocket-lint.com",
+        "co2": 0.5116776124716217,
+        "count": 2288.0
+    },
+    {
+        "key": "rockpapershotgun.com",
+        "co2": 0.3529546602823001,
+        "count": 1641.0
+    },
+    {
+        "key": "sallysbakingaddiction.com",
+        "co2": 0.4106069632093566,
+        "count": 2693.0
+    },
+    {
+        "key": "singletracks.com",
+        "co2": 0.24736521882222276,
+        "count": 2025.0
+    },
+    {
+        "key": "sopalk.com",
+        "co2": 0.23835016207835327,
+        "count": 17483.0
+    },
+    {
+        "key": "wrestlinginc.com",
+        "co2": 0.48823784239294654,
+        "count": 1981.0
+    },
+    {
+        "key": "admarvel.com",
+        "co2": 0.244370576158533,
+        "count": 1752.0
+    },
+    {
+        "key": "com.game.BubbleShooter@android",
+        "co2": 0.2293075028376895,
+        "count": 1480.0
+    },
+    {
+        "key": "detroitnews.com",
+        "co2": 0.29177604781461913,
+        "count": 7619.0
+    },
+    {
+        "key": "glamourmagazine.co.uk",
+        "co2": 0.2655517587294483,
+        "count": 2894.0
+    },
+    {
+        "key": "mailtimes.com.au",
+        "co2": 0.4005530349096323,
+        "count": 1531.0
+    },
+    {
+        "key": "newrepublic.com",
+        "co2": 0.2717540223138808,
+        "count": 2807.0
+    },
+    {
+        "key": "nfl.com",
+        "co2": 0.46199082257283763,
+        "count": 6879.0
+    },
+    {
+        "key": "rideapart.com",
+        "co2": 1.1835112839156692,
+        "count": 5732.0
+    },
+    {
+        "key": "allnurses.com",
+        "co2": 0.40137222285795765,
+        "count": 2963.0
+    },
+    {
+        "key": "arcadespot.com",
+        "co2": 0.6932623064566157,
+        "count": 4564.0
+    },
+    {
+        "key": "bleacherreport.com",
+        "co2": 0.26327631775877247,
+        "count": 22703.0
+    },
+    {
+        "key": "com.easy.currency.extra.androary@android",
+        "co2": 0.234937929401274,
+        "count": 1212.0
+    },
+    {
+        "key": "cooksinfo.com",
+        "co2": 0.4593267449685703,
+        "count": 4995.0
+    },
+    {
+        "key": "dailytimewaste.com",
+        "co2": 0.8787543145170258,
+        "count": 3199.0
+    },
+    {
+        "key": "flowkir.com",
+        "co2": 0.2663131964199648,
+        "count": 11111.0
+    },
+    {
+        "key": "game-solver.com",
+        "co2": 0.47673355180627786,
+        "count": 2450.0
+    },
+    {
+        "key": "politico.eu",
+        "co2": 0.27721036558731454,
+        "count": 3083.0
+    },
+    {
+        "key": "scrabblecheat.com",
+        "co2": 1.6547246934614848,
+        "count": 3286.0
+    },
+    {
+        "key": "transfermarkt.co.uk",
+        "co2": 1.0329687821933187,
+        "count": 4291.0
+    },
+    {
+        "key": "wwe.com",
+        "co2": 0.3676737979427537,
+        "count": 3433.0
+    },
+    {
+        "key": "com.crossword.bible.cookies.find.english@android",
+        "co2": 0.23110936483518313,
+        "count": 1139.0
+    },
+    {
+        "key": "com.queensgame.spider@android",
+        "co2": 0.23212101520876027,
+        "count": 1189.0
+    },
+    {
+        "key": "debatewise.org",
+        "co2": 0.30519101373117824,
+        "count": 3682.0
+    },
+    {
+        "key": "elle.com.au",
+        "co2": 0.37728387702237687,
+        "count": 17721.0
+    },
+    {
+        "key": "express.com.pk",
+        "co2": 0.4281241020893698,
+        "count": 1140.0
+    },
+    {
+        "key": "facebook.com",
+        "co2": 0.16044156457565448,
+        "count": 2193.0
+    },
+    {
+        "key": "ibtimes.com",
+        "co2": 0.42936525965958705,
+        "count": 290688.0
+    },
+    {
+        "key": "realgm.com",
+        "co2": 0.8749878004427788,
+        "count": 2290.0
+    },
+    {
+        "key": "theblondcook.com",
+        "co2": 0.3366327026984929,
+        "count": 3358.0
+    },
+    {
+        "key": "acquiremag.com",
+        "co2": 0.398059451724783,
+        "count": 1818.0
+    },
+    {
+        "key": "alfabb.com",
+        "co2": 0.6643505003880772,
+        "count": 7847.0
+    },
+    {
+        "key": "com.ovilex.trucksimulatorusa@android",
+        "co2": 0.23258875688639652,
+        "count": 1462.0
+    },
+    {
+        "key": "com.tureng.sozluk@android",
+        "co2": 0.24235875799621306,
+        "count": 1765.0
+    },
+    {
+        "key": "defence.pk",
+        "co2": 0.29264058104855717,
+        "count": 1608.0
+    },
+    {
+        "key": "domesblissity.com",
+        "co2": 0.5070216712047257,
+        "count": 2949.0
+    },
+    {
+        "key": "primis-amp.tech",
+        "co2": 0.8277492180549689,
+        "count": 48053.0
+    },
+    {
+        "key": "skyweather.com.au",
+        "co2": 0.26508265583104373,
+        "count": 1120.0
+    },
+    {
+        "key": "theatlantic.com",
+        "co2": 0.2563410890225241,
+        "count": 2833.0
+    },
+    {
+        "key": "wonderwall.com",
+        "co2": 0.3454398293288777,
+        "count": 3602.0
+    },
+    {
+        "key": "wwd.com",
+        "co2": 0.3479469615264833,
+        "count": 12260.0
+    },
+    {
+        "key": "anzuinfra.com",
+        "co2": 0.27041431958371553,
+        "count": 12548.0
+    },
+    {
+        "key": "bendigoadvertiser.com.au",
+        "co2": 0.3876272680052631,
+        "count": 1896.0
+    },
+    {
+        "key": "bounty.com",
+        "co2": 0.39585862565283825,
+        "count": 3109.0
+    },
+    {
+        "key": "com.camerasideas.instashot@android",
+        "co2": 0.23467377263957812,
+        "count": 1413.0
+    },
+    {
+        "key": "com.coffeebeanventures.easyvoicerecorder@android",
+        "co2": 0.22921238318122467,
+        "count": 1471.0
+    },
+    {
+        "key": "gamersheroes.com",
+        "co2": 0.9588427161802731,
+        "count": 6797.0
+    },
+    {
+        "key": "gq-magazine.co.uk",
+        "co2": 0.27844083371614337,
+        "count": 3878.0
+    },
+    {
+        "key": "homeaddict.io",
+        "co2": 0.39979373203161145,
+        "count": 4468.0
+    },
+    {
+        "key": "nextofwindows.com",
+        "co2": 0.32199710057473285,
+        "count": 2504.0
+    },
+    {
+        "key": "removeandreplace.com",
+        "co2": 1.5563898230459583,
+        "count": 4547.0
+    },
+    {
+        "key": "startappservice.com",
+        "co2": 0.24071725875420544,
+        "count": 2403.0
+    },
+    {
+        "key": "chefdehome.com",
+        "co2": 0.2846030795260601,
+        "count": 2005.0
+    },
+    {
+        "key": "com.KaueRosa.CityTakeover@android",
+        "co2": 0.23299677744265632,
+        "count": 1125.0
+    },
+    {
+        "key": "com.games2win.drivingacademy@android",
+        "co2": 0.23129086278401628,
+        "count": 1351.0
+    },
+    {
+        "key": "com.grofsoft.tripview.lite@android",
+        "co2": 0.2435974020731678,
+        "count": 7030.0
+    },
+    {
+        "key": "discoveryplus.com",
+        "co2": 0.47768754517411455,
+        "count": 101447.0
+    },
+    {
+        "key": "mapsofindia.com",
+        "co2": 0.848968811344786,
+        "count": 1895.0
+    },
+    {
+        "key": "ottstudio.plus",
+        "co2": 0.45883511416295697,
+        "count": 6321.0
+    },
+    {
+        "key": "thesportsdrop.com",
+        "co2": 1.024796644336368,
+        "count": 72131.0
+    },
+    {
+        "key": "vt.co",
+        "co2": 0.26962548742877007,
+        "count": 1495.0
+    },
+    {
+        "key": "aussiev8.com.au",
+        "co2": 0.27931490330719766,
+        "count": 3015.0
+    },
+    {
+        "key": "bandsintown.com",
+        "co2": 0.3727842150988744,
+        "count": 1038.0
+    },
+    {
+        "key": "boxofficeindia.com",
+        "co2": 0.734401521108727,
+        "count": 3539.0
+    },
+    {
+        "key": "buzznet.com",
+        "co2": 0.7182525950505197,
+        "count": 2978.0
+    },
+    {
+        "key": "com.kokteyl.mackolik@android",
+        "co2": 0.25213392111710264,
+        "count": 1339.0
+    },
+    {
+        "key": "elitedaily.com",
+        "co2": 0.2542301635526564,
+        "count": 1178.0
+    },
+    {
+        "key": "foodiebaker.com",
+        "co2": 0.5032260327492086,
+        "count": 4061.0
+    },
+    {
+        "key": "givemesport.com",
+        "co2": 0.8021387601391892,
+        "count": 6414.0
+    },
+    {
+        "key": "guitarnick.com",
+        "co2": 1.1570656793906475,
+        "count": 4401.0
+    },
+    {
+        "key": "happymoneysaver.com",
+        "co2": 0.3189971401110025,
+        "count": 1976.0
+    },
+    {
+        "key": "ibroxnoise.co.uk",
+        "co2": 0.9091071968569333,
+        "count": 4260.0
+    },
+    {
+        "key": "onecrazyhouse.com",
+        "co2": 0.3014321345488696,
+        "count": 5205.0
+    },
+    {
+        "key": "polygon.com",
+        "co2": 0.23540060565312554,
+        "count": 5140.0
+    },
+    {
+        "key": "tutorialspoint.com",
+        "co2": 0.5617900551651663,
+        "count": 48553.0
+    },
+    {
+        "key": "adelaidenow.com.au",
+        "co2": 0.24390248681132426,
+        "count": 89832.0
+    },
+    {
+        "key": "com.onecwireless.mahjong@android",
+        "co2": 0.23112312926900946,
+        "count": 1125.0
+    },
+    {
+        "key": "emulator-zone.com",
+        "co2": 1.3685248222695388,
+        "count": 2849.0
+    },
+    {
+        "key": "fifplay.com",
+        "co2": 0.6168118444504292,
+        "count": 4368.0
+    },
+    {
+        "key": "pipeburn.com",
+        "co2": 0.35774950640726716,
+        "count": 2162.0
+    },
+    {
+        "key": "rctech.net",
+        "co2": 0.4920976148607861,
+        "count": 3344.0
+    },
+    {
+        "key": "ru.galya.drawjoust@android",
+        "co2": 0.23538206048014487,
+        "count": 1525.0
+    },
+    {
+        "key": "shortlist.com",
+        "co2": 0.4624642438843558,
+        "count": 3032.0
+    },
+    {
+        "key": "techeblog.com",
+        "co2": 0.5650912064932115,
+        "count": 1914.0
+    },
+    {
+        "key": "triviaboss.com",
+        "co2": 0.6988090006946126,
+        "count": 4008.0
+    },
+    {
+        "key": "websleuths.com",
+        "co2": 1.6335754078170437,
+        "count": 2947.0
+    },
+    {
+        "key": "westleedsdispatch.com",
+        "co2": 0.22186428637186506,
+        "count": 49736.0
+    },
+    {
+        "key": "com.jogatina.buraco@android",
+        "co2": 0.2364833720633357,
+        "count": 1550.0
+    },
+    {
+        "key": "couriermail.com.au",
+        "co2": 0.275953987376021,
+        "count": 246389.0
+    },
+    {
+        "key": "delicious.com.au",
+        "co2": 0.25660811089641306,
+        "count": 22654.0
+    },
+    {
+        "key": "dsmtuners.com",
+        "co2": 0.28962548620022993,
+        "count": 2596.0
+    },
+    {
+        "key": "pixelpapercraft.com",
+        "co2": 0.29323099870948727,
+        "count": 1910.0
+    },
+    {
+        "key": "primermagazine.com",
+        "co2": 0.287043903832207,
+        "count": 2079.0
+    },
+    {
+        "key": "simpleveganblog.com",
+        "co2": 0.28801519804878345,
+        "count": 4620.0
+    },
+    {
+        "key": "t-nation.com",
+        "co2": 0.4061809885938577,
+        "count": 3607.0
+    },
+    {
+        "key": "thesixersense.com",
+        "co2": 0.6993653651638613,
+        "count": 1092.0
+    },
+    {
+        "key": "thethings.com",
+        "co2": 0.8042092784351266,
+        "count": 2914.0
+    },
+    {
+        "key": "aquariumadvice.com",
+        "co2": 0.3199419172701859,
+        "count": 3286.0
+    },
+    {
+        "key": "com.arabiaweather.main_app@android",
+        "co2": 0.24993261390683197,
+        "count": 6327.0
+    },
+    {
+        "key": "com.mippin.android.bw.m14581@android",
+        "co2": 0.23001971401020238,
+        "count": 1057.0
+    },
+    {
+        "key": "com.superbox.aos.jewelsjungle@android",
+        "co2": 0.23461969928442578,
+        "count": 1690.0
+    },
+    {
+        "key": "deadspin.com",
+        "co2": 0.29569563997354614,
+        "count": 1305.0
+    },
+    {
+        "key": "leasticoulddo.com",
+        "co2": 0.7707706919870503,
+        "count": 5308.0
+    },
+    {
+        "key": "likevertising.com",
+        "co2": 0.27151484474943355,
+        "count": 3578.0
+    },
+    {
+        "key": "macrumors.com",
+        "co2": 0.28816191573539174,
+        "count": 3605.0
+    },
+    {
+        "key": "spot.ph",
+        "co2": 0.5769017351027118,
+        "count": 6025.0
+    },
+    {
+        "key": "bet.com",
+        "co2": 0.5663772213880095,
+        "count": 1165.0
+    },
+    {
+        "key": "com.dencreak.dlcalculator@android",
+        "co2": 0.23804926416584926,
+        "count": 1161.0
+    },
+    {
+        "key": "com.outfit7.mytalkingtom2@android",
+        "co2": 0.24054494164234536,
+        "count": 2281.0
+    },
+    {
+        "key": "com.tranzmate@android",
+        "co2": 0.2362956908279624,
+        "count": 1273.0
+    },
+    {
+        "key": "creative-preview-an.com",
+        "co2": 0.3467218741687144,
+        "count": 5003.0
+    },
+    {
+        "key": "discogs.com",
+        "co2": 0.22870032806737517,
+        "count": 6446.0
+    },
+    {
+        "key": "gqindia.com",
+        "co2": 0.2893525684062353,
+        "count": 2229.0
+    },
+    {
+        "key": "heywise.com",
+        "co2": 0.5013898447174749,
+        "count": 2202.0
+    },
+    {
+        "key": "historyextra.com",
+        "co2": 0.2722682268032666,
+        "count": 3267.0
+    },
+    {
+        "key": "jacksonville.com",
+        "co2": 0.33154456206378713,
+        "count": 2007.0
+    },
+    {
+        "key": "nola.com",
+        "co2": 0.6505087408831198,
+        "count": 2392.0
+    },
+    {
+        "key": "s-onetag.com",
+        "co2": 0.25610404492613786,
+        "count": 2139.0
+    },
+    {
+        "key": "travelandleisure.com",
+        "co2": 0.24832579679939343,
+        "count": 1339.0
+    },
+    {
+        "key": "cuteness.com",
+        "co2": 0.561490851300576,
+        "count": 4242.0
+    },
+    {
+        "key": "digitalspy.com",
+        "co2": 0.3143075384101934,
+        "count": 5497.0
+    },
+    {
+        "key": "entrepreneur.com",
+        "co2": 0.46645740432524574,
+        "count": 219206.0
+    },
+    {
+        "key": "lifestyle.si.com",
+        "co2": 0.44827324580280964,
+        "count": 23555.0
+    },
+    {
+        "key": "null",
+        "co2": 0.27729630204722805,
+        "count": 7225.0
+    },
+    {
+        "key": "richouses.com",
+        "co2": 0.644170367767903,
+        "count": 1036.0
+    },
+    {
+        "key": "sunnyskyz.com",
+        "co2": 0.2981700900422704,
+        "count": 3102.0
+    },
+    {
+        "key": "theartofdoingstuff.com",
+        "co2": 0.33764798040765126,
+        "count": 3109.0
+    },
+    {
+        "key": "times-age.co.nz",
+        "co2": 0.20278814574664317,
+        "count": 2129.0
+    },
+    {
+        "key": "tractorbynet.com",
+        "co2": 1.4164596260376106,
+        "count": 3551.0
+    },
+    {
+        "key": "travelerdoor.com",
+        "co2": 0.3078677468324953,
+        "count": 8558.0
+    },
+    {
+        "key": "uk.co.thesun.mobile@android",
+        "co2": 0.23308070138551382,
+        "count": 1152.0
+    },
+    {
+        "key": "cnx-software.com",
+        "co2": 0.5640722652028248,
+        "count": 2166.0
+    },
+    {
+        "key": "com.game5mobile.lineandwater@android",
+        "co2": 0.2355344429621242,
+        "count": 2007.0
+    },
+    {
+        "key": "gazetaromaneasca.com",
+        "co2": 0.36569948317761664,
+        "count": 1036.0
+    },
+    {
+        "key": "gofugyourself.com",
+        "co2": 0.2604203263975309,
+        "count": 1618.0
+    },
+    {
+        "key": "hawkesburygazette.com.au",
+        "co2": 0.43041646309791204,
+        "count": 1163.0
+    },
+    {
+        "key": "mandurahmail.com.au",
+        "co2": 0.42360667124206286,
+        "count": 2609.0
+    },
+    {
+        "key": "maxpreps.com",
+        "co2": 0.36358147984802097,
+        "count": 4434.0
+    },
+    {
+        "key": "railpictures.net",
+        "co2": 0.2958175662658939,
+        "count": 4663.0
+    },
+    {
+        "key": "southernliving.com",
+        "co2": 0.2349715389813192,
+        "count": 1470.0
+    },
+    {
+        "key": "babynames.net",
+        "co2": 0.2633954379457785,
+        "count": 1444.0
+    },
+    {
+        "key": "brighteyedbaker.com",
+        "co2": 0.28383315000634,
+        "count": 2278.0
+    },
+    {
+        "key": "com.dictionary@android",
+        "co2": 0.2323837396124,
+        "count": 1086.0
+    },
+    {
+        "key": "cookpad.com",
+        "co2": 0.2498043751426111,
+        "count": 2225.0
+    },
+    {
+        "key": "elledecor.com",
+        "co2": 0.2780583676434709,
+        "count": 2160.0
+    },
+    {
+        "key": "fatforweightloss.com.au",
+        "co2": 0.29218544356009973,
+        "count": 3306.0
+    },
+    {
+        "key": "flashscore.com",
+        "co2": 0.25993471502413074,
+        "count": 10234.0
+    },
+    {
+        "key": "gardenersworld.com",
+        "co2": 0.3441777172667922,
+        "count": 4780.0
+    },
+    {
+        "key": "net.relaxio.relaxio@android",
+        "co2": 0.2279420907695612,
+        "count": 1211.0
+    },
+    {
+        "key": "odt.co.nz",
+        "co2": 0.18880251057987324,
+        "count": 16278.0
+    },
+    {
+        "key": "ohsheglows.com",
+        "co2": 0.2901837156212522,
+        "count": 2849.0
+    },
+    {
+        "key": "publicholidays.co.nz",
+        "co2": 0.5516345136207881,
+        "count": 3673.0
+    },
+    {
+        "key": "s2ki.com",
+        "co2": 0.32425277936777386,
+        "count": 2497.0
+    },
+    {
+        "key": "thecombineforum.com",
+        "co2": 0.6473040162783719,
+        "count": 3521.0
+    },
+    {
+        "key": "thetechgame.com",
+        "co2": 0.6828238895176667,
+        "count": 2975.0
+    },
+    {
+        "key": "ultimate-guitar.com",
+        "co2": 0.7516923039441851,
+        "count": 873287.0
+    },
+    {
+        "key": "ambitiouskitchen.com",
+        "co2": 0.36611550227709205,
+        "count": 1278.0
+    },
+    {
+        "key": "besteveralbums.com",
+        "co2": 0.3144728944283353,
+        "count": 3200.0
+    },
+    {
+        "key": "bluemountainsgazette.com.au",
+        "co2": 0.4214523759595717,
+        "count": 2662.0
+    },
+    {
+        "key": "com.instantbits.cast.webvideo@android",
+        "co2": 0.23265520019342534,
+        "count": 1432.0
+    },
+    {
+        "key": "disqus.com",
+        "co2": 0.27043324384206296,
+        "count": 4754.0
+    },
+    {
+        "key": "doityourself.com",
+        "co2": 0.503940828936637,
+        "count": 1331.0
+    },
+    {
+        "key": "garavigujarat.biz",
+        "co2": 0.30466843449277736,
+        "count": 1349.0
+    },
+    {
+        "key": "gazzetta.it",
+        "co2": 1.1720432795513478,
+        "count": 2959.0
+    },
+    {
+        "key": "getreading.co.uk",
+        "co2": 0.8355889866278251,
+        "count": 2767.0
+    },
+    {
+        "key": "goodmenproject.com",
+        "co2": 0.28506980586457253,
+        "count": 1479.0
+    },
+    {
+        "key": "guitarworld.com",
+        "co2": 1.0357939133174277,
+        "count": 3486.0
+    },
+    {
+        "key": "journalistate.com",
+        "co2": 0.825509417459803,
+        "count": 32449.0
+    },
+    {
+        "key": "kalynskitchen.com",
+        "co2": 0.299802071788754,
+        "count": 2331.0
+    },
+    {
+        "key": "macleayargus.com.au",
+        "co2": 0.42506556356572095,
+        "count": 1029.0
+    },
+    {
+        "key": "marketwatch.com",
+        "co2": 0.2719850321106352,
+        "count": 1295.0
+    },
+    {
+        "key": "mashable.com",
+        "co2": 0.6437568482774164,
+        "count": 3509.0
+    },
+    {
+        "key": "mixedmartialarts.com",
+        "co2": 0.5023277998807704,
+        "count": 27697.0
+    },
+    {
+        "key": "motorsearches.com",
+        "co2": 1.1557089483042113,
+        "count": 18471.0
+    },
+    {
+        "key": "tunein.player@android",
+        "co2": 0.18434297466843774,
+        "count": 1038.0
+    },
+    {
+        "key": "yummy.ph",
+        "co2": 0.9112724114874994,
+        "count": 4905.0
+    },
+    {
+        "key": "bicycling.com",
+        "co2": 0.28184235421388804,
+        "count": 3411.0
+    },
+    {
+        "key": "curejoy.com",
+        "co2": 0.43132831766133134,
+        "count": 3783.0
+    },
+    {
+        "key": "driveaccord.net",
+        "co2": 0.659125681018506,
+        "count": 1328.0
+    },
+    {
+        "key": "healthyway.com",
+        "co2": 0.2901395852667801,
+        "count": 2597.0
+    },
+    {
+        "key": "priceme.co.nz",
+        "co2": 0.5335718240364948,
+        "count": 5043.0
+    },
+    {
+        "key": "somewhatsimple.com",
+        "co2": 0.3143282727720735,
+        "count": 2077.0
+    },
+    {
+        "key": "spine-health.com",
+        "co2": 0.25589072382940753,
+        "count": 3880.0
+    },
+    {
+        "key": "thefunpost.com",
+        "co2": 0.42956392474343047,
+        "count": 7440.0
+    },
+    {
+        "key": "addapinch.com",
+        "co2": 0.2910286488501586,
+        "count": 1802.0
+    },
+    {
+        "key": "cheaprecipeblog.com",
+        "co2": 0.2914077782383271,
+        "count": 2721.0
+    },
+    {
+        "key": "com.bitsmedia.android.muslimpro@android",
+        "co2": 0.23145387294564243,
+        "count": 2122.0
+    },
+    {
+        "key": "com.merriamwebster@android",
+        "co2": 0.23792026874291325,
+        "count": 5267.0
+    },
+    {
+        "key": "foxestalk.co.uk",
+        "co2": 0.2836754343106263,
+        "count": 3624.0
+    },
+    {
+        "key": "handyman.net.au",
+        "co2": 0.5804904244743146,
+        "count": 5094.0
+    },
+    {
+        "key": "indexmundi.com",
+        "co2": 0.35868872705634314,
+        "count": 1943.0
+    },
+    {
+        "key": "indianmotorcycles.net",
+        "co2": 0.6521662626453849,
+        "count": 2309.0
+    },
+    {
+        "key": "nextrefinance.com",
+        "co2": 0.906717207585438,
+        "count": 1155.0
+    },
+    {
+        "key": "personalwatercraft.com",
+        "co2": 0.559313244136504,
+        "count": 2281.0
+    },
+    {
+        "key": "statesman.com",
+        "co2": 0.34020153990767943,
+        "count": 1502.0
+    },
+    {
+        "key": "vanguardngr.com",
+        "co2": 0.885030028881459,
+        "count": 1565.0
+    },
+    {
+        "key": "worldisraelnews.com",
+        "co2": 0.29844189847592306,
+        "count": 5727.0
+    },
+    {
+        "key": "yorkpress.co.uk",
+        "co2": 0.4223722445566219,
+        "count": 1953.0
+    },
+    {
+        "key": "com.gazeus.euchre@android",
+        "co2": 0.23781888497636824,
+        "count": 1130.0
+    },
+    {
+        "key": "consolegameswiki.com",
+        "co2": 0.4399431369873504,
+        "count": 7326.0
+    },
+    {
+        "key": "howcast.com",
+        "co2": 0.4181152309615521,
+        "count": 1476.0
+    },
+    {
+        "key": "newsandstar.co.uk",
+        "co2": 0.4230127873209802,
+        "count": 1241.0
+    },
+    {
+        "key": "pennlive.com",
+        "co2": 0.3059998897860619,
+        "count": 3604.0
+    },
+    {
+        "key": "silive.com",
+        "co2": 0.3003265204673841,
+        "count": 1288.0
+    },
+    {
+        "key": "smokingmeatforums.com",
+        "co2": 0.3085273315367151,
+        "count": 1452.0
+    },
+    {
+        "key": "syracuse.com",
+        "co2": 0.29985420847657246,
+        "count": 1698.0
+    },
+    {
+        "key": "tasty.co",
+        "co2": 0.4089525088702451,
+        "count": 2081.0
+    },
+    {
+        "key": "volarenovels.com",
+        "co2": 0.5920386733993136,
+        "count": 1419.0
+    },
+    {
+        "key": "ana-base.wis.pr",
+        "co2": 0.2607591229032901,
+        "count": 55948.0
+    },
+    {
+        "key": "dailystar.co.uk",
+        "co2": 0.9763449033296285,
+        "count": 1174.0
+    },
+    {
+        "key": "dallasnews.com",
+        "co2": 0.3047716337931941,
+        "count": 2085.0
+    },
+    {
+        "key": "fijivillage.com",
+        "co2": 0.24502360633335835,
+        "count": 1068.0
+    },
+    {
+        "key": "greencarreports.com",
+        "co2": 0.4092982752486786,
+        "count": 1110.0
+    },
+    {
+        "key": "huffingtonpost.co.uk",
+        "co2": 1.8853814150603982,
+        "count": 2116.0
+    },
+    {
+        "key": "irv2.com",
+        "co2": 0.3230497937504757,
+        "count": 1680.0
+    },
+    {
+        "key": "natureworldtoday.com",
+        "co2": 0.5535103503813837,
+        "count": 1610.0
+    },
+    {
+        "key": "oilersnation.com",
+        "co2": 0.8461153347932748,
+        "count": 3319.0
+    },
+    {
+        "key": "paininthearsenal.com",
+        "co2": 0.7321893059941003,
+        "count": 4439.0
+    },
+    {
+        "key": "planetrugby.com",
+        "co2": 0.4562396286704652,
+        "count": 5727.0
+    },
+    {
+        "key": "rollcall.com",
+        "co2": 0.29555697359056615,
+        "count": 1100.0
+    },
+    {
+        "key": "sysprobs.com",
+        "co2": 1.2786670960188864,
+        "count": 1305.0
+    },
+    {
+        "key": "thedailymeal.com",
+        "co2": 0.31992094931263826,
+        "count": 2470.0
+    },
+    {
+        "key": "theshaderoom.com",
+        "co2": 0.39305876084206587,
+        "count": 1100.0
+    },
+    {
+        "key": "topsecretrecipes.com",
+        "co2": 0.28253703573319866,
+        "count": 1762.0
+    },
+    {
+        "key": "trend-chaser.com",
+        "co2": 0.7208067989272265,
+        "count": 1301.0
+    },
+    {
+        "key": "tripadvisor.co.nz",
+        "co2": 0.20831910864482756,
+        "count": 3580.0
+    },
+    {
+        "key": "wheeloffortuneanswer.com",
+        "co2": 0.6685053048109707,
+        "count": 2232.0
+    },
+    {
+        "key": "worldstar.com",
+        "co2": 0.6731144315322148,
+        "count": 11900.0
+    },
+    {
+        "key": "yupitsvegan.com",
+        "co2": 0.2808062973212712,
+        "count": 3494.0
+    },
+    {
+        "key": "abbreviations.com",
+        "co2": 0.2801723684445244,
+        "count": 2541.0
+    },
+    {
+        "key": "afl.com.au",
+        "co2": 0.3471257951273828,
+        "count": 1881.0
+    },
+    {
+        "key": "areanews.com.au",
+        "co2": 0.4154665246336392,
+        "count": 1346.0
+    },
+    {
+        "key": "bhg.com.au",
+        "co2": 0.5236158066636523,
+        "count": 1837.0
+    },
+    {
+        "key": "bollywoodlife.com",
+        "co2": 0.9459142462793053,
+        "count": 5222.0
+    },
+    {
+        "key": "com.bigduckgames.flowbridges@android",
+        "co2": 0.2301774410859399,
+        "count": 1685.0
+    },
+    {
+        "key": "com.espn.score_center@android",
+        "co2": 0.23022740772013534,
+        "count": 4549.0
+    },
+    {
+        "key": "darkhorizons.com",
+        "co2": 0.4632810700005239,
+        "count": 4094.0
+    },
+    {
+        "key": "hotcars.com",
+        "co2": 0.7850816375215742,
+        "count": 5078.0
+    },
+    {
+        "key": "inverse.com",
+        "co2": 0.26914712915220806,
+        "count": 6209.0
+    },
+    {
+        "key": "jessicagavin.com",
+        "co2": 0.3572351044234719,
+        "count": 1096.0
+    },
+    {
+        "key": "kpopstarz.com",
+        "co2": 0.40250752961864694,
+        "count": 2024.0
+    },
+    {
+        "key": "list25.com",
+        "co2": 0.7562623111583519,
+        "count": 1935.0
+    },
+    {
+        "key": "loveandlemons.com",
+        "co2": 0.42453455920534067,
+        "count": 1858.0
+    },
+    {
+        "key": "matichon.co.th",
+        "co2": 1.930227412203993,
+        "count": 10303.0
+    },
+    {
+        "key": "mmafighting.com",
+        "co2": 0.46229224850185857,
+        "count": 1364.0
+    },
+    {
+        "key": "pupabc.com",
+        "co2": 0.8762686434601652,
+        "count": 9112.0
+    },
+    {
+        "key": "swarb.co.uk",
+        "co2": 1.2770373869176976,
+        "count": 1373.0
+    },
+    {
+        "key": "theleader.com.au",
+        "co2": 0.4177040170132648,
+        "count": 8289.0
+    },
+    {
+        "key": "todayscreativelife.com",
+        "co2": 0.2911437227278131,
+        "count": 1729.0
+    },
+    {
+        "key": "a.league.live@android",
+        "co2": 0.2357451400255226,
+        "count": 1367.0
+    },
+    {
+        "key": "com.myyearbook.m@android",
+        "co2": 0.23142887574997303,
+        "count": 4807.0
+    },
+    {
+        "key": "horseracingnation.com",
+        "co2": 0.5649069916949334,
+        "count": 2866.0
+    },
+    {
+        "key": "jamieoliver.com",
+        "co2": 0.5087346907885636,
+        "count": 2324.0
+    },
+    {
+        "key": "kakuroconquest.com",
+        "co2": 0.24668843292748568,
+        "count": 1057.0
+    },
+    {
+        "key": "newser.com",
+        "co2": 0.6328955863757277,
+        "count": 1041.0
+    },
+    {
+        "key": "startrek.com",
+        "co2": 0.35228450641648285,
+        "count": 1418.0
+    },
+    {
+        "key": "stilltasty.com",
+        "co2": 0.6046047330578455,
+        "count": 1760.0
+    },
+    {
+        "key": "africatwinforum.com",
+        "co2": 0.6802794520512984,
+        "count": 1931.0
+    },
+    {
+        "key": "amomama.com",
+        "co2": 0.5632445293467644,
+        "count": 9836.0
+    },
+    {
+        "key": "cntxcdm.com",
+        "co2": 0.41556459899552967,
+        "count": 60146.0
+    },
+    {
+        "key": "downshiftology.com",
+        "co2": 0.42092415716407106,
+        "count": 2332.0
+    },
+    {
+        "key": "grizly.com",
+        "co2": 0.6474153224194235,
+        "count": 2749.0
+    },
+    {
+        "key": "herald.co.zw",
+        "co2": 0.3062092456713135,
+        "count": 1107.0
+    },
+    {
+        "key": "idiva.com",
+        "co2": 0.5097260717598291,
+        "count": 1063.0
+    },
+    {
+        "key": "lyricsmode.com",
+        "co2": 0.2838810629063045,
+        "count": 1107.0
+    },
+    {
+        "key": "net.metapps.sleepsounds@android",
+        "co2": 0.2290118171469574,
+        "count": 2740.0
+    },
+    {
+        "key": "onceuponachef.com",
+        "co2": 0.31353303001232025,
+        "count": 5028.0
+    },
+    {
+        "key": "onlymyhealth.com",
+        "co2": 1.1367923667377395,
+        "count": 1055.0
+    },
+    {
+        "key": "petguide.com",
+        "co2": 0.3245562360627899,
+        "count": 86267.0
+    },
+    {
+        "key": "phonearena.com",
+        "co2": 0.6217332630165805,
+        "count": 3293.0
+    },
+    {
+        "key": "smitefire.com",
+        "co2": 0.3058105651253915,
+        "count": 1731.0
+    },
+    {
+        "key": "southernrevivals.com",
+        "co2": 0.28035547188841237,
+        "count": 1527.0
+    },
+    {
+        "key": "thediplomat.com",
+        "co2": 0.26962833831917615,
+        "count": 5707.0
+    },
+    {
+        "key": "theedge.co.nz",
+        "co2": 0.19224871216000902,
+        "count": 1505.0
+    },
+    {
+        "key": "themediterraneandish.com",
+        "co2": 0.44081057089803416,
+        "count": 1678.0
+    },
+    {
+        "key": "thesportster.com",
+        "co2": 0.8119728485550813,
+        "count": 2417.0
+    },
+    {
+        "key": "tiphero.com",
+        "co2": 0.3021081385123432,
+        "count": 1985.0
+    },
+    {
+        "key": "usingenglish.com",
+        "co2": 0.7567412394939309,
+        "count": 1957.0
+    },
+    {
+        "key": "12tomatoes.com",
+        "co2": 0.4261061885089032,
+        "count": 1100.0
+    },
+    {
+        "key": "bloomberg.com",
+        "co2": 0.5425576806763089,
+        "count": 1484.0
+    },
+    {
+        "key": "fetchtv.com.au",
+        "co2": 0.47879802522249565,
+        "count": 5351.0
+    },
+    {
+        "key": "foodisinthehouse.com",
+        "co2": 1.4222666738373098,
+        "count": 2518.0
+    },
+    {
+        "key": "irishtimes.com",
+        "co2": 0.3054902612962466,
+        "count": 1328.0
+    },
+    {
+        "key": "prevention.com",
+        "co2": 0.2776985056366493,
+        "count": 1017.0
+    },
+    {
+        "key": "sunstar.com.ph",
+        "co2": 1.0903990662770282,
+        "count": 1457.0
+    },
+    {
+        "key": "sweetlittlebluebird.com",
+        "co2": 0.30765680098669873,
+        "count": 3058.0
+    },
+    {
+        "key": "trumpexcel.com",
+        "co2": 0.4792219417056527,
+        "count": 1455.0
+    },
+    {
+        "key": "wowhead.com",
+        "co2": 1.1020808919023946,
+        "count": 60226.0
+    },
+    {
+        "key": "abc7ny.com",
+        "co2": 0.29577306531706116,
+        "count": 1489.0
+    },
+    {
+        "key": "allmusic.com",
+        "co2": 0.6496072347293693,
+        "count": 1553.0
+    },
+    {
+        "key": "babynamespedia.com",
+        "co2": 0.2536366975474167,
+        "count": 3213.0
+    },
+    {
+        "key": "bettycrocker.com",
+        "co2": 0.2740200303381537,
+        "count": 1758.0
+    },
+    {
+        "key": "bigo.sg",
+        "co2": 0.2681798120144928,
+        "count": 70924.0
+    },
+    {
+        "key": "bobshideout.com",
+        "co2": 0.6022466254438595,
+        "count": 14260.0
+    },
+    {
+        "key": "carscoops.com",
+        "co2": 0.37849955914323913,
+        "count": 1221.0
+    },
+    {
+        "key": "dermnetnz.org",
+        "co2": 0.9648054869963673,
+        "count": 3931.0
+    },
+    {
+        "key": "feastingathome.com",
+        "co2": 0.5089130796400366,
+        "count": 4662.0
+    },
+    {
+        "key": "flashnetic.com",
+        "co2": 0.24223663473962448,
+        "count": 4794.0
+    },
+    {
+        "key": "healthygreenkitchen.com",
+        "co2": 0.2988250359303104,
+        "count": 1571.0
+    },
+    {
+        "key": "iplocation.net",
+        "co2": 1.0415218703480207,
+        "count": 4370.0
+    },
+    {
+        "key": "justamumnz.com",
+        "co2": 0.24451271041249684,
+        "count": 4108.0
+    },
+    {
+        "key": "magicseaweed.com",
+        "co2": 0.21098770148904808,
+        "count": 2523.0
+    },
+    {
+        "key": "media.net",
+        "co2": 0.24490799962994125,
+        "count": 1005.0
+    },
+    {
+        "key": "number-2-pencil.com",
+        "co2": 0.31584253154058284,
+        "count": 1462.0
+    },
+    {
+        "key": "photopea.com",
+        "co2": 1.0873196426127496,
+        "count": 4867.0
+    },
+    {
+        "key": "polarisatvforums.com",
+        "co2": 0.7549262028292759,
+        "count": 1011.0
+    },
+    {
+        "key": "reviewjournal.com",
+        "co2": 0.4467975367217174,
+        "count": 1128.0
+    },
+    {
+        "key": "roadbikereview.com",
+        "co2": 0.6543491386076677,
+        "count": 3672.0
+    },
+    {
+        "key": "rottentomatoes.com",
+        "co2": 0.2635076315338712,
+        "count": 4506.0
+    },
+    {
+        "key": "theappear.com",
+        "co2": 0.8933607011531695,
+        "count": 3800.0
+    },
+    {
+        "key": "thedaddest.com",
+        "co2": 0.27578344615650396,
+        "count": 11350.0
+    },
+    {
+        "key": "therandyreport.com",
+        "co2": 0.6853406417820683,
+        "count": 2570.0
+    },
+    {
+        "key": "tyla.com",
+        "co2": 0.9000092336819278,
+        "count": 3881.0
+    },
+    {
+        "key": "unbelievable-facts.com",
+        "co2": 0.511831681353838,
+        "count": 4449.0
+    },
+    {
+        "key": "weqyoua.pro",
+        "co2": 0.740836813417419,
+        "count": 3002.0
+    },
+    {
+        "key": "wherethesmileshavebeen.com",
+        "co2": 0.29388746729369336,
+        "count": 5566.0
+    },
+    {
+        "key": "amazingribs.com",
+        "co2": 0.3011179619869889,
+        "count": 2151.0
+    },
+    {
+        "key": "bestbuy.com",
+        "co2": 0.2383228470254094,
+        "count": 1109.0
+    },
+    {
+        "key": "celebritynetworth.com",
+        "co2": 0.3059216797381846,
+        "count": 1857.0
+    },
+    {
+        "key": "chlloe.com",
+        "co2": 0.7535449562273188,
+        "count": 8662.0
+    },
+    {
+        "key": "cricbuzz.com",
+        "co2": 0.5143947737359152,
+        "count": 1375.0
+    },
+    {
+        "key": "discovery.com",
+        "co2": 0.5075590869959329,
+        "count": 11930.0
+    },
+    {
+        "key": "eightieskids.com",
+        "co2": 0.5850723227353454,
+        "count": 3799.0
+    },
+    {
+        "key": "emilybites.com",
+        "co2": 0.3203997985242255,
+        "count": 1750.0
+    },
+    {
+        "key": "good-loop.com",
+        "co2": 0.327859593677373,
+        "count": 1677.0
+    },
+    {
+        "key": "independentaustralia.net",
+        "co2": 0.24637601249555677,
+        "count": 4484.0
+    },
+    {
+        "key": "livingetc.com",
+        "co2": 0.9048931423364635,
+        "count": 1017.0
+    },
+    {
+        "key": "priceoftravel.com",
+        "co2": 0.364541535486284,
+        "count": 1309.0
+    },
+    {
+        "key": "sandiegouniontribune.com",
+        "co2": 0.2905729137018786,
+        "count": 1086.0
+    },
+    {
+        "key": "theecofeed.com",
+        "co2": 0.4428878710774244,
+        "count": 14259.0
+    },
+    {
+        "key": "ticketmaster.com.au",
+        "co2": 0.24228798597980758,
+        "count": 18844.0
+    },
+    {
+        "key": "tunefind.com",
+        "co2": 0.9407334003388624,
+        "count": 4198.0
+    },
+    {
+        "key": "whathifi.com",
+        "co2": 0.9475321140135946,
+        "count": 2107.0
+    },
+    {
+        "key": "www.y8.com",
+        "co2": 0.6777404138945716,
+        "count": 1072.0
+    },
+    {
+        "key": "abola.pt",
+        "co2": 0.41968387327091655,
+        "count": 12683.0
+    },
+    {
+        "key": "autoevolution.com",
+        "co2": 0.4041210216637602,
+        "count": 1967.0
+    },
+    {
+        "key": "azureedge.net",
+        "co2": 0.27403863240790555,
+        "count": 29024.0
+    },
+    {
+        "key": "bestpap.com",
+        "co2": 1.2618878639189992,
+        "count": 4349.0
+    },
+    {
+        "key": "esquire.com",
+        "co2": 0.306659436116371,
+        "count": 2101.0
+    },
+    {
+        "key": "ewscloud.com",
+        "co2": 0.45969627189316475,
+        "count": 2327.0
+    },
+    {
+        "key": "golfmonthly.com",
+        "co2": 0.9374326721249849,
+        "count": 1107.0
+    },
+    {
+        "key": "interesticle.com",
+        "co2": 0.7523632968315893,
+        "count": 18319.0
+    },
+    {
+        "key": "menshealth.com",
+        "co2": 0.338830216237515,
+        "count": 1174.0
+    },
+    {
+        "key": "playbuzz.com",
+        "co2": 0.3387557094758522,
+        "count": 2978.0
+    },
+    {
+        "key": "shanty-2-chic.com",
+        "co2": 0.29877593946309844,
+        "count": 1223.0
+    },
+    {
+        "key": "toocool2betrue.com",
+        "co2": 0.9815954614621194,
+        "count": 241915.0
+    },
+    {
+        "key": "toyotaownersclub.com",
+        "co2": 0.3758379203029002,
+        "count": 2753.0
+    },
+    {
+        "key": "unitedinfocus.com",
+        "co2": 0.6981108185691675,
+        "count": 1578.0
+    },
+    {
+        "key": "vg247.com",
+        "co2": 0.3614157851298192,
+        "count": 2645.0
+    },
+    {
+        "key": "workshop-manuals.com",
+        "co2": 0.32820201634698204,
+        "count": 1523.0
+    },
+    {
+        "key": "aseasyasapplepie.com",
+        "co2": 0.31794595582291485,
+        "count": 10999.0
+    },
+    {
+        "key": "asianhospitality.com",
+        "co2": 1.1021180882679686,
+        "count": 1280.0
+    },
+    {
+        "key": "bodyandsoul.com.au",
+        "co2": 0.2527241547599874,
+        "count": 2540.0
+    },
+    {
+        "key": "goodto.com",
+        "co2": 0.8879837718251998,
+        "count": 1241.0
+    },
+    {
+        "key": "kdramastars.com",
+        "co2": 0.40231714098634425,
+        "count": 1634.0
+    },
+    {
+        "key": "minecraftmods.com",
+        "co2": 0.6144655282432778,
+        "count": 1874.0
+    },
+    {
+        "key": "motor1.com",
+        "co2": 0.623271633542071,
+        "count": 1361.0
+    },
+    {
+        "key": "runnersworld.com",
+        "co2": 0.2909006089963085,
+        "count": 1394.0
+    },
+    {
+        "key": "tenplay.com.au",
+        "co2": 0.501871245305605,
+        "count": 4435.0
+    },
+    {
+        "key": "thedailymash.co.uk",
+        "co2": 0.5461537028386597,
+        "count": 2749.0
+    },
+    {
+        "key": "thedelite.com",
+        "co2": 0.4025055158255537,
+        "count": 1833.0
+    },
+    {
+        "key": "bridesblush.com",
+        "co2": 0.4903651924178594,
+        "count": 107702.0
+    },
+    {
+        "key": "channelnewsasia.com",
+        "co2": 0.2802749516314586,
+        "count": 1146.0
+    },
+    {
+        "key": "flicks.co.nz",
+        "co2": 0.2157434659355851,
+        "count": 1005.0
+    },
+    {
+        "key": "good.is",
+        "co2": 0.5046671741911342,
+        "count": 3237.0
+    },
+    {
+        "key": "hammers.news",
+        "co2": 0.6845456963639992,
+        "count": 7221.0
+    },
+    {
+        "key": "lonny.com",
+        "co2": 0.40598103507705446,
+        "count": 1355.0
+    },
+    {
+        "key": "magiquiz.com",
+        "co2": 0.33414009733271965,
+        "count": 1351.0
+    },
+    {
+        "key": "milesplit.com",
+        "co2": 0.26122669420280004,
+        "count": 1158.0
+    },
+    {
+        "key": "pogo.com",
+        "co2": 0.4772658096854482,
+        "count": 1417.0
+    },
+    {
+        "key": "popsugar.com.au",
+        "co2": 0.24449735239191192,
+        "count": 5473.0
+    },
+    {
+        "key": "powerofpositivity.com",
+        "co2": 0.26102288802916246,
+        "count": 2051.0
+    },
+    {
+        "key": "soolide.com",
+        "co2": 0.5118432228403732,
+        "count": 18648.0
+    },
+    {
+        "key": "visordown.com",
+        "co2": 0.4732757860354472,
+        "count": 2015.0
+    },
+    {
+        "key": "xfinity.com",
+        "co2": 0.7120403697497232,
+        "count": 39987.0
+    },
+    {
+        "key": "xxlmag.com",
+        "co2": 0.4641074625295268,
+        "count": 12419.0
+    },
+    {
+        "key": "ziilch.com",
+        "co2": 1.1523144058794699,
+        "count": 1293.0
+    },
+    {
+        "key": "electrek.co",
+        "co2": 0.3687160287872189,
+        "count": 12962.0
+    },
+    {
+        "key": "familyhandyman.com",
+        "co2": 0.5927476510648669,
+        "count": 2541.0
+    },
+    {
+        "key": "iheartnaptime.net",
+        "co2": 0.25864954374763066,
+        "count": 1144.0
+    },
+    {
+        "key": "intouchweekly.com",
+        "co2": 0.3999444943550438,
+        "count": 1187.0
+    },
+    {
+        "key": "iol.co.za",
+        "co2": 0.3308268775225467,
+        "count": 1059.0
+    },
+    {
+        "key": "jaybirdtv.com",
+        "co2": 0.45665863452060795,
+        "count": 2325.0
+    },
+    {
+        "key": "ntnews.com.au",
+        "co2": 0.2555437077409748,
+        "count": 2011.0
+    },
+    {
+        "key": "olayomad.com",
+        "co2": 0.27512131721625344,
+        "count": 5124.0
+    },
+    {
+        "key": "openx.net",
+        "co2": 0.26503784554227416,
+        "count": 7737.0
+    },
+    {
+        "key": "playwire.com",
+        "co2": 0.4142535572748125,
+        "count": 18909.0
+    },
+    {
+        "key": "practicalparenting.com.au",
+        "co2": 0.27864264051628906,
+        "count": 2920.0
+    },
+    {
+        "key": "socdm.com",
+        "co2": 0.2730812171275611,
+        "count": 170830.0
+    },
+    {
+        "key": "softonic.com",
+        "co2": 1.17526095304481,
+        "count": 30678.0
+    },
+    {
+        "key": "watwait.com",
+        "co2": 0.28203200293005265,
+        "count": 12304.0
+    },
+    {
+        "key": "women.com",
+        "co2": 0.2614442776943867,
+        "count": 5465.0
+    },
+    {
+        "key": "bestrecipes.com.au",
+        "co2": 0.23058386822270452,
+        "count": 9232.0
+    },
+    {
+        "key": "businessdesk.co.nz",
+        "co2": 0.1717406663762914,
+        "count": 9501.0
+    },
+    {
+        "key": "chipchick.com",
+        "co2": 1.1842519971096628,
+        "count": 8523.0
+    },
+    {
+        "key": "cleanmyspace.com",
+        "co2": 0.3405503980355951,
+        "count": 1893.0
+    },
+    {
+        "key": "cooktopcove.com",
+        "co2": 0.21430573146779663,
+        "count": 1752.0
+    },
+    {
+        "key": "distractify.com",
+        "co2": 0.4595733694373069,
+        "count": 5767.0
+    },
+    {
+        "key": "driven.co.nz",
+        "co2": 0.1733214537372477,
+        "count": 17320.0
+    },
+    {
+        "key": "escape.com.au",
+        "co2": 0.24320787828160026,
+        "count": 2866.0
+    },
+    {
+        "key": "fantoly.com",
+        "co2": 0.2720763850713941,
+        "count": 2883.0
+    },
+    {
+        "key": "ffxblue.com.au",
+        "co2": 0.26970410919434457,
+        "count": 1245.0
+    },
+    {
+        "key": "halfbakedharvest.com",
+        "co2": 0.30766471579386895,
+        "count": 2136.0
+    },
+    {
+        "key": "heroinvesting.com",
+        "co2": 0.5555278144225738,
+        "count": 1073.0
+    },
+    {
+        "key": "jpost.com",
+        "co2": 1.0356632216390953,
+        "count": 4427.0
+    },
+    {
+        "key": "loudwire.com",
+        "co2": 0.7325517103815927,
+        "count": 2030.0
+    },
+    {
+        "key": "mbappgewtmmbsgy3daobqhe888888.com",
+        "co2": 0.2683442758606419,
+        "count": 3675.0
+    },
+    {
+        "key": "medicinenet.com",
+        "co2": 0.5216496207666166,
+        "count": 4668.0
+    },
+    {
+        "key": "musi-simple-music-streaming/id591560124@ios",
+        "co2": 0.23409625805995282,
+        "count": 145696.0
+    },
+    {
+        "key": "naver.com",
+        "co2": 0.26455124951430586,
+        "count": 10662.0
+    },
+    {
+        "key": "newindianexpress.com",
+        "co2": 0.5667553864018019,
+        "count": 98518.0
+    },
+    {
+        "key": "petapixel.com",
+        "co2": 0.5130778531146702,
+        "count": 1095.0
+    },
+    {
+        "key": "pgatour.com",
+        "co2": 0.22789449781511226,
+        "count": 1444.0
+    },
+    {
+        "key": "pinkuk.com",
+        "co2": 0.21556646968673676,
+        "count": 1062.0
+    },
+    {
+        "key": "thefreedictionary.com",
+        "co2": 0.5298838853842215,
+        "count": 2499.0
+    },
+    {
+        "key": "thetradedesk.com",
+        "co2": 0.30096005102601886,
+        "count": 1137.0
+    },
+    {
+        "key": "tlc.com",
+        "co2": 0.5022029032535421,
+        "count": 36565.0
+    },
+    {
+        "key": "twtd.co.uk",
+        "co2": 1.7094447099884997,
+        "count": 1900.0
+    },
+    {
+        "key": "withmyladies.com",
+        "co2": 0.41759362964482033,
+        "count": 2652.0
+    },
+    {
+        "key": "xda-developers.com",
+        "co2": 1.0923079932833393,
+        "count": 3575.0
+    },
+    {
+        "key": "beautycrew.com.au",
+        "co2": 0.35453825010332596,
+        "count": 4394.0
+    },
+    {
+        "key": "com.lihkg.app@android",
+        "co2": 0.2301812119813368,
+        "count": 4102.0
+    },
+    {
+        "key": "confiant-qa.com",
+        "co2": 0.3275581289723273,
+        "count": 3995.0
+    },
+    {
+        "key": "d20srd.org",
+        "co2": 0.33932974031276586,
+        "count": 1520.0
+    },
+    {
+        "key": "faroutmagazine.co.uk",
+        "co2": 0.5933529125033965,
+        "count": 3596.0
+    },
+    {
+        "key": "gamepress.gg",
+        "co2": 0.6551887409213623,
+        "count": 4055.0
+    },
+    {
+        "key": "gg2.net",
+        "co2": 0.35774939169582864,
+        "count": 2543.0
+    },
+    {
+        "key": "gloriousa.com",
+        "co2": 0.7834505192649429,
+        "count": 8257.0
+    },
+    {
+        "key": "goldcoastbulletin.com.au",
+        "co2": 0.2667066183491362,
+        "count": 2669.0
+    },
+    {
+        "key": "gooya.com",
+        "co2": 0.2665597959802912,
+        "count": 8196.0
+    },
+    {
+        "key": "hgtv.com",
+        "co2": 0.5091640197419168,
+        "count": 12972.0
+    },
+    {
+        "key": "instantlymodern.com",
+        "co2": 0.27209509156140593,
+        "count": 2945.0
+    },
+    {
+        "key": "ketoconnect.net",
+        "co2": 0.28291314185104227,
+        "count": 2473.0
+    },
+    {
+        "key": "leeds-live.co.uk",
+        "co2": 0.9343160153576566,
+        "count": 2126.0
+    },
+    {
+        "key": "mbappgiwwg33nfzshk33mnfxgo3y8.com",
+        "co2": 0.2227939124146259,
+        "count": 4031.0
+    },
+    {
+        "key": "metasrc.com",
+        "co2": 0.5378703803829391,
+        "count": 3662.0
+    },
+    {
+        "key": "moneyppl.com",
+        "co2": 0.4116991545070797,
+        "count": 1628.0
+    },
+    {
+        "key": "nation.africa",
+        "co2": 0.7346101482513824,
+        "count": 25944.0
+    },
+    {
+        "key": "onechicagocenter.com",
+        "co2": 0.7898193326783755,
+        "count": 1993.0
+    },
+    {
+        "key": "parentmood.com",
+        "co2": 0.4205138788303601,
+        "count": 4146.0
+    },
+    {
+        "key": "pcgamesn.com",
+        "co2": 0.6685789174479121,
+        "count": 4675.0
+    },
+    {
+        "key": "play.google.com",
+        "co2": 0.27732410435462745,
+        "count": 12564858.0
+    },
+    {
+        "key": "playsimple.wordtrip",
+        "co2": 0.2615289929220508,
+        "count": 921526.0
+    },
+    {
+        "key": "pupperish.com",
+        "co2": 1.3767409363482603,
+        "count": 8215.0
+    },
+    {
+        "key": "setlist.fm",
+        "co2": 0.2444733069365035,
+        "count": 3499.0
+    },
+    {
+        "key": "sharingsmiles.co",
+        "co2": 0.8527593128042168,
+        "count": 3608.0
+    },
+    {
+        "key": "sneakertoast.com",
+        "co2": 0.27058082086349605,
+        "count": 4208.0
+    },
+    {
+        "key": "tasty-yummies.com",
+        "co2": 0.32159683588984644,
+        "count": 1091.0
+    },
+    {
+        "key": "techytwist.com",
+        "co2": 0.2940321655019907,
+        "count": 1472.0
+    },
+    {
+        "key": "themercury.com.au",
+        "co2": 0.2004322496593469,
+        "count": 4543.0
+    },
+    {
+        "key": "thetab.com",
+        "co2": 0.5729547837027389,
+        "count": 5080.0
+    },
+    {
+        "key": "theydiffer.com",
+        "co2": 0.7659525896567522,
+        "count": 1512.0
+    },
+    {
+        "key": "toptiphacks.com",
+        "co2": 0.4071426883161961,
+        "count": 1942.0
+    },
+    {
+        "key": "townsvillebulletin.com.au",
+        "co2": 0.26523537913920714,
+        "count": 1050.0
+    },
+    {
+        "key": "wrestletalk.com",
+        "co2": 0.5466024174729956,
+        "count": 2091.0
+    },
+    {
+        "key": "untappd-discover-beer/id449141888@ios",
+        "co2": 0.23552851562171762,
+        "count": 1345.0
+    },
+    {
+        "key": "chapterzmagazine.com",
+        "co2": 0.2462455139666258,
+        "count": 4624.0
+    },
+    {
+        "key": "genbusa.com",
+        "co2": 0.2191772794398321,
+        "count": 6732.0
+    },
+    {
+        "key": "au.com.cricket@android",
+        "co2": 0.23099434190795867,
+        "count": 3775.0
+    },
+    {
+        "key": "cleverclassic.com",
+        "co2": 0.2844742378243962,
+        "count": 3403.0
+    },
+    {
+        "key": "fabcrunch.com",
+        "co2": 0.2962632105288812,
+        "count": 3281.0
+    },
+    {
+        "key": "golfmagic.com",
+        "co2": 0.464380002023186,
+        "count": 1536.0
+    },
+    {
+        "key": "u.gg",
+        "co2": 1.3790736175151461,
+        "count": 10085.0
+    },
+    {
+        "key": "geekzone.co.nz",
+        "co2": 0.5795579922125598,
+        "count": 6852.0
+    },
+    {
+        "key": "medical-news.org",
+        "co2": 0.3959989150381228,
+        "count": 13047.0
+    },
+    {
+        "key": "mraid.ads",
+        "co2": 0.268706228602055,
+        "count": 4866.0
+    },
+    {
+        "key": "ticketmaster.co.nz",
+        "co2": 0.1662466882173794,
+        "count": 1826.0
+    },
+    {
+        "key": "chunkbase.com",
+        "co2": 0.4953807376785134,
+        "count": 3649.0
+    },
+    {
+        "key": "femanin.com",
+        "co2": 1.0139139155387096,
+        "count": 2391.0
+    },
+    {
+        "key": "heraldweekly.com",
+        "co2": 0.8274818819596375,
+        "count": 56630.0
+    },
+    {
+        "key": "indiatvnews.com",
+        "co2": 0.44828709492763824,
+        "count": 23624.0
+    },
+    {
+        "key": "pubmine.com",
+        "co2": 0.2576932146333621,
+        "count": 3342.0
+    },
+    {
+        "key": "apnetv.to",
+        "co2": 0.709844457446055,
+        "count": 3795.0
+    },
+    {
+        "key": "autosport.com",
+        "co2": 0.9076488149637078,
+        "count": 1991.0
+    },
+    {
+        "key": "com.tour.pgatour@android",
+        "co2": 0.2393232377601586,
+        "count": 1806.0
+    },
+    {
+        "key": "historictalk.com",
+        "co2": 0.44311344507098105,
+        "count": 3043.0
+    },
+    {
+        "key": "laughingsquid.com",
+        "co2": 0.545675081693018,
+        "count": 12185.0
+    },
+    {
+        "key": "lensvid.com",
+        "co2": 0.810269066268705,
+        "count": 2811.0
+    },
+    {
+        "key": "mbappgiwwg33nfzuw45dtnfts4y3bnvzwgylonzsxe888.com",
+        "co2": 0.19375920535669558,
+        "count": 2752.0
+    },
+    {
+        "key": "motor-junkie.com",
+        "co2": 0.5264028718111514,
+        "count": 3482.0
+    },
+    {
+        "key": "musicradar.com",
+        "co2": 1.1023271644492199,
+        "count": 5197.0
+    },
+    {
+        "key": "oneroof.co.nz",
+        "co2": 0.18304326923941983,
+        "count": 30893.0
+    },
+    {
+        "key": "reallifediy.com",
+        "co2": 0.4441658450242809,
+        "count": 3225.0
+    },
+    {
+        "key": "rxlist.com",
+        "co2": 0.5275581827276096,
+        "count": 1898.0
+    },
+    {
+        "key": "shropshirestar.com",
+        "co2": 0.5279673549193625,
+        "count": 1339.0
+    },
+    {
+        "key": "wackojaco.com",
+        "co2": 0.4151807166393717,
+        "count": 4560.0
+    },
+    {
+        "key": "solitaire/id1166981451@ios",
+        "co2": 0.231549908791106,
+        "count": 2124.0
+    },
+    {
+        "key": "com.sony.nfx.app.sfrc@android",
+        "co2": 0.22734863382539128,
+        "count": 1025.0
+    },
+    {
+        "key": "gamerant.com",
+        "co2": 0.9173376852144258,
+        "count": 25795.0
+    },
+    {
+        "key": "obsev.com",
+        "co2": 0.3674802739007201,
+        "count": 5708.0
+    },
+    {
+        "key": "1010/id911793120@ios",
+        "co2": 0.2662484570837154,
+        "count": 1132.0
+    },
+    {
+        "key": "drivepedia.com",
+        "co2": 0.2933253452470232,
+        "count": 1586.0
+    },
+    {
+        "key": "funcatz.com",
+        "co2": 0.3577386209151434,
+        "count": 2462.0
+    },
+    {
+        "key": "pepperscale.com",
+        "co2": 0.3307686179129532,
+        "count": 1591.0
+    },
+    {
+        "key": "9to5google.com",
+        "co2": 0.3656624093193909,
+        "count": 9117.0
+    },
+    {
+        "key": "cairnspost.com.au",
+        "co2": 0.2623262772376446,
+        "count": 1320.0
+    },
+    {
+        "key": "coolmathgames.com",
+        "co2": 0.3387265438689914,
+        "count": 3632.0
+    },
+    {
+        "key": "geoguessr.com",
+        "co2": 0.9362451775846427,
+        "count": 2220.0
+    },
+    {
+        "key": "lobandsmash.com",
+        "co2": 0.7866069143051488,
+        "count": 1286.0
+    },
+    {
+        "key": "thefashionball.com",
+        "co2": 0.30116010830392276,
+        "count": 1201.0
+    },
+    {
+        "key": "warcraftlogs.com",
+        "co2": 0.7318824898329528,
+        "count": 1086.0
+    },
+    {
+        "key": "whythese.com",
+        "co2": 0.396064424013279,
+        "count": 4682.0
+    },
+    {
+        "key": "withthefirstpick.com",
+        "co2": 0.7157516523117216,
+        "count": 2394.0
+    },
+    {
+        "key": "worldtravelling.com",
+        "co2": 0.5861370829352952,
+        "count": 3420.0
+    },
+    {
+        "key": "wrufer.com",
+        "co2": 0.2724695246159932,
+        "count": 11036.0
+    },
+    {
+        "key": "moneyawaits.com",
+        "co2": 1.182164350211682,
+        "count": 2440.0
+    },
+    {
+        "key": "brightside.me",
+        "co2": 1.2749626214456355,
+        "count": 3698.0
+    },
+    {
+        "key": "beyondtheflag.com",
+        "co2": 0.587101846680129,
+        "count": 2679.0
+    },
+    {
+        "key": "alcasthq.com",
+        "co2": 0.6609146749815477,
+        "count": 2347.0
+    },
+    {
+        "key": "culturess.com",
+        "co2": 0.8863754310341545,
+        "count": 3845.0
+    },
+    {
+        "key": "daily-choices.com",
+        "co2": 0.8148631521853522,
+        "count": 4881.0
+    },
+    {
+        "key": "fanbyte.com",
+        "co2": 1.0943544000711625,
+        "count": 1595.0
+    },
+    {
+        "key": "footballscotland.co.uk",
+        "co2": 0.9351966576644998,
+        "count": 1296.0
+    },
+    {
+        "key": "omnicalculator.com",
+        "co2": 1.0547062990230867,
+        "count": 1954.0
+    },
+    {
+        "key": "pastchronicles.com",
+        "co2": 0.8105830599410819,
+        "count": 4646.0
+    },
+    {
+        "key": "science1st.com",
+        "co2": 0.5154499552907571,
+        "count": 6140.0
+    },
+    {
+        "key": "stocktwits.com",
+        "co2": 1.0642798229666872,
+        "count": 1090.0
+    },
+    {
+        "key": "thesource.com",
+        "co2": 0.43701690209468624,
+        "count": 13737.0
+    },
+    {
+        "key": "skyracing.com.au",
+        "co2": 0.5324024215920972,
+        "count": 1385.0
+    },
+    {
+        "key": "alphr.com",
+        "co2": 0.9005638129346497,
+        "count": 2293.0
+    },
+    {
+        "key": "lse.co.uk",
+        "co2": 0.9325052352241322,
+        "count": 15937.0
+    },
+    {
+        "key": "mabelandmoxie.com",
+        "co2": 0.3869061705569942,
+        "count": 1481.0
+    },
+    {
+        "key": "babymed.com",
+        "co2": 0.2882163436535238,
+        "count": 2880.0
+    },
+    {
+        "key": "livingly.com",
+        "co2": 0.39947304777632164,
+        "count": 4461.0
+    },
+    {
+        "key": "dailybee.com",
+        "co2": 0.5114721617250565,
+        "count": 30498.0
+    },
+    {
+        "key": "videowalldirect.com",
+        "co2": 0.25418724678871785,
+        "count": 1921.0
+    },
+    {
+        "key": "bikeradar.com",
+        "co2": 0.39510756147722437,
+        "count": 1211.0
+    },
+    {
+        "key": "genshin.gg",
+        "co2": 0.6467641415553892,
+        "count": 1593.0
+    },
+    {
+        "key": "rangersnews.uk",
+        "co2": 0.6643093450609576,
+        "count": 6429.0
+    },
+    {
+        "key": "sportzbonanza.com",
+        "co2": 1.6812923008556122,
+        "count": 1234.0
+    },
+    {
+        "key": "thechelseachronicle.com",
+        "co2": 0.6207411745060589,
+        "count": 4623.0
+    },
+    {
+        "key": "time.is",
+        "co2": 0.5163084499126243,
+        "count": 1793.0
+    },
+    {
+        "key": "yoursportspot.com",
+        "co2": 1.368826626658202,
+        "count": 5429.0
+    },
+    {
+        "key": "comcast.net",
+        "co2": 0.4608511141951472,
+        "count": 8508.0
+    },
+    {
+        "key": "diyeverywhere.com",
+        "co2": 0.21272057926548685,
+        "count": 2844.0
+    },
+    {
+        "key": "agame.com",
+        "co2": 0.31375616515523236,
+        "count": 1467.0
+    },
+    {
+        "key": "boxing-social.com",
+        "co2": 0.5647401526900723,
+        "count": 31214.0
+    },
+    {
+        "key": "carsguide.com.au",
+        "co2": 0.26284857193705474,
+        "count": 1004098.0
+    },
+    {
+        "key": "daily-stuff.com",
+        "co2": 0.9463328919503631,
+        "count": 2746.0
+    },
+    {
+        "key": "neighbourly.co.nz",
+        "co2": 0.19795464299257998,
+        "count": 1668.0
+    },
+    {
+        "key": "wordsearch.wordbliss",
+        "co2": 0.26376490112953005,
+        "count": 3814.0
+    },
+    {
+        "key": "autoguide.com",
+        "co2": 0.3769337096902591,
+        "count": 3640.0
+    },
+    {
+        "key": "ballercap.com",
+        "co2": 0.27512484584799024,
+        "count": 8406.0
+    },
+    {
+        "key": "bamsmackpow.com",
+        "co2": 0.8246194359090983,
+        "count": 2310.0
+    },
+    {
+        "key": "finance1st.com",
+        "co2": 0.4013624714087915,
+        "count": 1588.0
+    },
+    {
+        "key": "parade.com",
+        "co2": 1.438192181114026,
+        "count": 4388.0
+    },
+    {
+        "key": "simpleflying.com",
+        "co2": 0.8021396274946142,
+        "count": 3473.0
+    },
+    {
+        "key": "ssacdn.com",
+        "co2": 0.265471321890288,
+        "count": 2435.0
+    },
+    {
+        "key": "theaustralian.com.au",
+        "co2": 0.26006468264591703,
+        "count": 146256.0
+    },
+    {
+        "key": "thetalko.com",
+        "co2": 0.7266703832748709,
+        "count": 1812.0
+    },
+    {
+        "key": "bigglobaltravel.com",
+        "co2": 0.3011184144390365,
+        "count": 1516.0
+    },
+    {
+        "key": "directv.com",
+        "co2": 0.5272865926729734,
+        "count": 7608.0
+    },
+    {
+        "key": "trueachievements.com",
+        "co2": 0.5949741165595575,
+        "count": 11310.0
+    },
+    {
+        "key": "ranker.com",
+        "co2": 0.8521940896440493,
+        "count": 25923.0
+    },
+    {
+        "key": "ziarulromanesc.net",
+        "co2": 0.2513620806455789,
+        "count": 25357.0
+    },
+    {
+        "key": "footballleagueworld.co.uk",
+        "co2": 1.4046735503816314,
+        "count": 7461.0
+    },
+    {
+        "key": "racedepartment.com",
+        "co2": 0.46753402380381875,
+        "count": 2908.0
+    },
+    {
+        "key": "worldfootball.net",
+        "co2": 0.5994686131779402,
+        "count": 4982.0
+    },
+    {
+        "key": "tftactics.gg",
+        "co2": 0.7219064683861414,
+        "count": 11766.0
+    },
+    {
+        "key": "baeldung.com",
+        "co2": 0.8981584035088431,
+        "count": 6667.0
+    },
+    {
+        "key": "poemanalysis.com",
+        "co2": 0.41858270601967795,
+        "count": 1107.0
+    },
+    {
+        "key": "psnprofiles.com",
+        "co2": 0.8222445889275682,
+        "count": 2224.0
+    },
+    {
+        "key": "techypu.com",
+        "co2": 0.48008009152597564,
+        "count": 2271.0
+    },
+    {
+        "key": "footballfancast.com",
+        "co2": 1.632499696123078,
+        "count": 5981.0
+    },
+    {
+        "key": "officialcharts.com",
+        "co2": 0.49860693328199646,
+        "count": 5262.0
+    },
+    {
+        "key": "unilad.com",
+        "co2": 0.880419853673581,
+        "count": 11701.0
+    },
+    {
+        "key": "bluestacks.com",
+        "co2": 0.6014161630530261,
+        "count": 3607.0
+    },
+    {
+        "key": "talktalk.co.uk",
+        "co2": 0.41424064633463853,
+        "count": 10055.0
+    },
+    {
+        "key": "dugout.com",
+        "co2": 0.38630859488242963,
+        "count": 3492.0
+    },
+    {
+        "key": "morehackz.com",
+        "co2": 0.3149987347965537,
+        "count": 7662.0
+    },
+    {
+        "key": "the-sun.com",
+        "co2": 0.6402553523403922,
+        "count": 4298.0
+    },
+    {
+        "key": "sudoku.com",
+        "co2": 0.6697215027634029,
+        "count": 22693.0
+    },
+    {
+        "key": "67hailhail.com",
+        "co2": 0.7539266570143685,
+        "count": 11479.0
+    },
+    {
+        "key": "rugbynetwork.net",
+        "co2": 0.42266129957849946,
+        "count": 2365.0
+    },
+    {
+        "key": "todayindestiny.com",
+        "co2": 0.5660225874742874,
+        "count": 2807.0
+    },
+    {
+        "key": "tracker.network",
+        "co2": 0.9779576391449015,
+        "count": 4691.0
+    },
+    {
+        "key": "mydiwise.com",
+        "co2": 0.3350923962789464,
+        "count": 4952.0
+    },
+    {
+        "key": "prothomalo.com",
+        "co2": 1.4999743661203653,
+        "count": 3022.0
+    },
+    {
+        "key": "gamingbible.com",
+        "co2": 0.45997412293960677,
+        "count": 6069.0
+    },
+    {
+        "key": "radiotimes.com",
+        "co2": 0.4127627191702842,
+        "count": 2619.0
+    },
+    {
+        "key": "rousingthekop.com",
+        "co2": 0.6599553064210832,
+        "count": 1631.0
+    },
+    {
+        "key": "bluegazette.com",
+        "co2": 0.4027292542171981,
+        "count": 1140.0
+    },
+    {
+        "key": "tbrfootball.com",
+        "co2": 0.7752244176258208,
+        "count": 4165.0
+    },
+    {
+        "key": "linuxhint.com",
+        "co2": 0.492884545858838,
+        "count": 1689.0
+    },
+    {
+        "key": "history-a2z.com",
+        "co2": 0.9328008797279347,
+        "count": 3934.0
+    },
+    {
+        "key": "musescore.com",
+        "co2": 0.5056792128935592,
+        "count": 1365.0
+    },
+    {
+        "key": "pockettactics.com",
+        "co2": 0.5316890551243347,
+        "count": 1380.0
+    },
+    {
+        "key": "travlerz.com",
+        "co2": 0.3383405406809101,
+        "count": 1756.0
+    },
+    {
+        "key": "wheelofnames.com",
+        "co2": 1.285662353023098,
+        "count": 1510.0
+    },
+    {
+        "key": "geordiebootboys.com",
+        "co2": 0.6458151869963268,
+        "count": 2166.0
+    },
+    {
+        "key": "ginx.tv",
+        "co2": 1.8248042809918004,
+        "count": 2344.0
+    },
+    {
+        "key": "kckingdom.com",
+        "co2": 0.8891520417230598,
+        "count": 1084.0
+    },
+    {
+        "key": "londonist.com",
+        "co2": 0.3894699103906658,
+        "count": 2015.0
+    },
+    {
+        "key": "myfryingpan.com",
+        "co2": 0.4154756131676924,
+        "count": 2897.0
+    },
+    {
+        "key": "thenerdstash.com",
+        "co2": 0.42302930149941725,
+        "count": 1220.0
+    },
+    {
+        "key": "ontvtonight.com",
+        "co2": 0.7312073818855138,
+        "count": 48797.0
+    },
+    {
+        "key": "satisfactory-calculator.com",
+        "co2": 0.4349270310205235,
+        "count": 1581.0
+    },
+    {
+        "key": "theloadout.com",
+        "co2": 0.7044312290827666,
+        "count": 2402.0
+    },
+    {
+        "key": "thestar.co.uk",
+        "co2": 1.1995691206586014,
+        "count": 2312.0
+    },
+    {
+        "key": "portsmouth.co.uk",
+        "co2": 1.2792982412107945,
+        "count": 1678.0
+    },
+    {
+        "key": "indy100.com",
+        "co2": 0.42120639471227145,
+        "count": 1382.0
+    },
+    {
+        "key": "itrwrestling.com",
+        "co2": 0.49388615365880695,
+        "count": 1165.0
+    },
+    {
+        "key": "nottinghamforest.news",
+        "co2": 0.639625688688795,
+        "count": 1244.0
+    },
+    {
+        "key": "oldschool.tools",
+        "co2": 0.7276534329186297,
+        "count": 1687.0
+    },
+    {
+        "key": "sussexexpress.co.uk",
+        "co2": 1.1927751807485698,
+        "count": 1612.0
+    },
+    {
+        "key": "boxrec.com",
+        "co2": 0.7725089789130056,
+        "count": 27571.0
+    },
+    {
+        "key": "winteriscoming.net",
+        "co2": 0.8797106291314605,
+        "count": 3090.0
+    },
+    {
+        "key": "glasgowworld.com",
+        "co2": 1.1842766086458167,
+        "count": 1520.0
+    },
+    {
+        "key": "insidethemagic.net",
+        "co2": 0.4665462132414077,
+        "count": 1122.0
+    },
+    {
+        "key": "gpfans.com",
+        "co2": 1.3558007510919554,
+        "count": 1791.0
+    },
+    {
+        "key": "gtaboom.com",
+        "co2": 0.5209746261644813,
+        "count": 1820.0
+    },
+    {
+        "key": "sportsmole.co.uk",
+        "co2": 1.2651668899641477,
+        "count": 1960.0
+    },
+    {
+        "key": "hebbarskitchen.com",
+        "co2": 0.5062934040180623,
+        "count": 2585.0
+    },
+    {
+        "key": "leedsunited.news",
+        "co2": 0.502769443938806,
+        "count": 1276.0
+    },
+    {
+        "key": "mcpedl.com",
+        "co2": 0.759853804599289,
+        "count": 2041.0
+    },
+    {
+        "key": "metatft.com",
+        "co2": 0.47814963123794213,
+        "count": 1187.0
+    },
+    {
+        "key": "royalroad.com",
+        "co2": 0.29314661561903466,
+        "count": 1026.0
+    },
+    {
+        "key": "wargamer.com",
+        "co2": 0.6008494822304582,
+        "count": 1114.0
+    },
+    {
+        "key": "weregreenly.com",
+        "co2": 0.35471953733925765,
+        "count": 1179.0
+    },
+    {
+        "key": "advfn.com",
+        "co2": 0.6144680319886594,
+        "count": 1917.0
+    },
+    {
+        "key": "game8.co",
+        "co2": 0.9434789345975148,
+        "count": 26416.0
+    },
+    {
+        "key": "geekybase.com",
+        "co2": 0.29609008706650214,
+        "count": 1862.0
+    },
+    {
+        "key": "lastnighton.com",
+        "co2": 0.8154870879442491,
+        "count": 4664.0
+    },
+    {
+        "key": "nationalclubgolfer.com",
+        "co2": 0.5579890461708589,
+        "count": 6329.0
+    },
+    {
+        "key": "healthandwellnesnews.com",
+        "co2": 0.3066024083127618,
+        "count": 1576.0
+    },
+    {
+        "key": "seniorsdiscountclub.com.au",
+        "co2": 0.6108941084210691,
+        "count": 6680.0
+    },
+    {
+        "key": "worldofsolitaire.com",
+        "co2": 0.9019716893135588,
+        "count": 15530.0
+    },
+    {
+        "key": "progolfnow.com",
+        "co2": 0.6675573522214944,
+        "count": 1196.0
+    },
+    {
+        "key": "sportdfw.com",
+        "co2": 0.9123708440918382,
+        "count": 1681.0
+    },
+    {
+        "key": "thecollector.com",
+        "co2": 0.5545172634186665,
+        "count": 2715.0
+    },
+    {
+        "key": "yorkshirepost.co.uk",
+        "co2": 1.2745426925831287,
+        "count": 1072.0
+    },
+    {
+        "key": "exceldemy.com",
+        "co2": 0.44835049770011176,
+        "count": 1622.0
+    },
+    {
+        "key": "gamewith.net",
+        "co2": 0.6873394373197206,
+        "count": 8956.0
+    },
+    {
+        "key": "soo-healthy.com",
+        "co2": 0.34423423010011833,
+        "count": 1841.0
+    },
+    {
+        "key": "theblast.com",
+        "co2": 0.518051705508354,
+        "count": 5442.0
+    },
+    {
+        "key": "dualshockers.com",
+        "co2": 0.7967517456288534,
+        "count": 1828.0
+    },
+    {
+        "key": "racooned.com",
+        "co2": 0.32004268050579504,
+        "count": 3668.0
+    },
+    {
+        "key": "themarysue.com",
+        "co2": 0.45644969562028476,
+        "count": 30504.0
+    },
+    {
+        "key": "automateexcel.com",
+        "co2": 0.716135989625331,
+        "count": 1762.0
+    },
+    {
+        "key": "claireandjamie.com",
+        "co2": 0.8092687575869217,
+        "count": 1251.0
+    },
+    {
+        "key": "docjournals.com",
+        "co2": 0.2587542427855245,
+        "count": 1802.0
+    },
+    {
+        "key": "octordle.com",
+        "co2": 0.27582947846265127,
+        "count": 1659.0
+    },
+    {
+        "key": "primagames.com",
+        "co2": 0.5144244332381929,
+        "count": 1861.0
+    },
+    {
+        "key": "tuko.co.ke",
+        "co2": 0.5710100246706099,
+        "count": 1552.0
+    },
+    {
+        "key": "aternos.org",
+        "co2": 0.5549603052908685,
+        "count": 15614.0
+    },
+    {
+        "key": "bartleby.com",
+        "co2": 1.000720275478137,
+        "count": 2645.0
+    },
+    {
+        "key": "drivingtodays.com",
+        "co2": 0.3013122021079676,
+        "count": 1155.0
+    },
+    {
+        "key": "fadeawayworld.net",
+        "co2": 0.6806974455771636,
+        "count": 4545.0
+    },
+    {
+        "key": "precincttv.com",
+        "co2": 0.8586308381979146,
+        "count": 2809.0
+    },
+    {
+        "key": "entertainmentdaily.co.uk",
+        "co2": 1.0112085864490143,
+        "count": 4993.0
+    },
+    {
+        "key": "gamersdecide.com",
+        "co2": 0.5491661007937304,
+        "count": 8137.0
+    },
+    {
+        "key": "legit.ng",
+        "co2": 0.5620541374109367,
+        "count": 1159.0
+    },
+    {
+        "key": "progameguides.com",
+        "co2": 0.48009112010738325,
+        "count": 23284.0
+    },
+    {
+        "key": "tunebat.com",
+        "co2": 0.5677882460037987,
+        "count": 1848.0
+    },
+    {
+        "key": "zeldadungeon.net",
+        "co2": 0.5101045857622597,
+        "count": 5947.0
+    },
+    {
+        "key": "androidpolice.com",
+        "co2": 0.879890919920433,
+        "count": 2502.0
+    },
+    {
+        "key": "bettermanly.com",
+        "co2": 0.36186832284337056,
+        "count": 3173.0
+    },
+    {
+        "key": "getemoji.com",
+        "co2": 0.46353462144848756,
+        "count": 3617.0
+    },
+    {
+        "key": "servers-minecraft.net",
+        "co2": 0.6214120674819267,
+        "count": 1495.0
+    },
+    {
+        "key": "techcurved.com",
+        "co2": 1.1197487285143504,
+        "count": 3656.0
+    },
+    {
+        "key": "tracker.gg",
+        "co2": 1.0465486496240628,
+        "count": 14549.0
+    },
+    {
+        "key": "filmibeat.com",
+        "co2": 0.6577203230374712,
+        "count": 77985.0
+    },
+    {
+        "key": "investing1st.com",
+        "co2": 0.463132084450319,
+        "count": 1852.0
+    },
+    {
+        "key": "newsonground.com",
+        "co2": 1.3624319740993742,
+        "count": 1261.0
+    },
+    {
+        "key": "online-solitaire.com",
+        "co2": 0.8813985764627822,
+        "count": 4311.0
+    },
+    {
+        "key": "oprah.com",
+        "co2": 0.4778505054469281,
+        "count": 8802.0
+    },
+    {
+        "key": "playclassic.games",
+        "co2": 0.8208992691950934,
+        "count": 1087.0
+    },
+    {
+        "key": "relativelyinteresting.com",
+        "co2": 0.5175120955655429,
+        "count": 2050.0
+    },
+    {
+        "key": "wrestlingheadlines.com",
+        "co2": 0.545534962111965,
+        "count": 1115.0
+    },
+    {
+        "key": "deltiasgaming.com",
+        "co2": 0.8780320064721269,
+        "count": 1135.0
+    },
+    {
+        "key": "excellenttown.com",
+        "co2": 0.3213772460274501,
+        "count": 1702.0
+    },
+    {
+        "key": "gamepur.com",
+        "co2": 0.4636486569881666,
+        "count": 18819.0
+    },
+    {
+        "key": "gamerjournalist.com",
+        "co2": 0.4584705745976491,
+        "count": 18090.0
+    },
+    {
+        "key": "lastwordonsports.com",
+        "co2": 1.0504985544944232,
+        "count": 3627.0
+    },
+    {
+        "key": "livescore.com",
+        "co2": 0.5389687530826874,
+        "count": 1108.0
+    },
+    {
+        "key": "readysteadycut.com",
+        "co2": 0.887803211346264,
+        "count": 1086.0
+    },
+    {
+        "key": "realoem.com",
+        "co2": 1.4653326282317525,
+        "count": 1574.0
+    },
+    {
+        "key": "rhymejunkie.com",
+        "co2": 0.6622081457429021,
+        "count": 1212.0
+    },
+    {
+        "key": "romanticfeed.com",
+        "co2": 0.45144440621940324,
+        "count": 2692.0
+    },
+    {
+        "key": "rugbyonslaught.com",
+        "co2": 0.5938748127774407,
+        "count": 5033.0
+    },
+    {
+        "key": "trontv.com",
+        "co2": 0.25894361128925447,
+        "count": 2545.0
+    },
+    {
+        "key": "vix.com",
+        "co2": 0.43882874888625656,
+        "count": 1868.0
+    },
+    {
+        "key": "womensweeklyfood.com.au",
+        "co2": 0.309049417042191,
+        "count": 37581.0
+    },
+    {
+        "key": "worldlifestyle.com",
+        "co2": 0.45277685105534526,
+        "count": 1659444.0
+    },
+    {
+        "key": "buzzfeednews.com",
+        "co2": 0.6028563184828677,
+        "count": 2174.0
+    },
+    {
+        "key": "tiffytaffy.com",
+        "co2": 0.7131826044575704,
+        "count": 1151.0
+    },
+    {
+        "key": "nowtolove.co.nz",
+        "co2": 0.21406452186540878,
+        "count": 1583.0
+    },
+    {
+        "key": "sodramaticonline.com",
+        "co2": 0.9284570816449095,
+        "count": 17199.0
+    },
+    {
+        "key": "gameloft.com",
+        "co2": 0.5208886211238118,
+        "count": 1476.0
+    },
+    {
+        "key": "hollywoodreporter.com",
+        "co2": 0.4450885906480233,
+        "count": 1083.0
+    },
+    {
+        "key": "everydaymonkey.com",
+        "co2": 1.0177747685404461,
+        "count": 2573.0
+    },
+    {
+        "key": "liquipedia.net",
+        "co2": 0.635126344198826,
+        "count": 1398.0
+    },
+    {
+        "key": "lowkickmma.com",
+        "co2": 0.29042966009423454,
+        "count": 1488.0
+    },
+    {
+        "key": "teuteuf.fr",
+        "co2": 0.5456476993805371,
+        "count": 1614.0
+    },
+    {
+        "key": "topgear.com",
+        "co2": 0.27716535246915025,
+        "count": 1388.0
+    },
+    {
+        "key": "whereisxur.com",
+        "co2": 0.7633802501396587,
+        "count": 1306.0
+    },
+    {
+        "key": "rainberrytv.com",
+        "co2": 0.18516626822511126,
+        "count": 35538.0
+    },
+    {
+        "key": "chordify.net",
+        "co2": 0.6120596372945276,
+        "count": 1843.0
+    },
+    {
+        "key": "flashb.id",
+        "co2": 0.22304664192730342,
+        "count": 2091.0
+    },
+    {
+        "key": "samaa.tv",
+        "co2": 0.3591055265509879,
+        "count": 3384.0
+    },
+    {
+        "key": "epicnpc.com",
+        "co2": 0.2982307364473886,
+        "count": 5045.0
+    },
+    {
+        "key": "artigercek.com",
+        "co2": 0.30241161913778614,
+        "count": 23031.0
+    },
+    {
+        "key": "attitude.co.uk",
+        "co2": 0.39694797498719797,
+        "count": 30541.0
+    },
+    {
+        "key": "loop.tv",
+        "co2": 0.6110224124327096,
+        "count": 594421.0
+    },
+    {
+        "key": "medicalnewstoday.com",
+        "co2": 0.5081576740321575,
+        "count": 2702.0
+    },
+    {
+        "key": "jewishnews.co.uk",
+        "co2": 0.24681167768259174,
+        "count": 41130.0
+    },
+    {
+        "key": "proudout.com",
+        "co2": 0.45796847503468385,
+        "count": 3169.0
+    },
+    {
+        "key": "chords-and-tabs.net",
+        "co2": 0.5184611221286414,
+        "count": 1150.0
+    },
+    {
+        "key": "computerhope.com",
+        "co2": 1.5940851900579918,
+        "count": 14482.0
+    },
+    {
+        "key": "ok.co.uk",
+        "co2": 1.0507465646780958,
+        "count": 3973.0
+    },
+    {
+        "key": "history.com",
+        "co2": 0.4476544800844876,
+        "count": 4327.0
+    },
+    {
+        "key": "mylifetime.com",
+        "co2": 0.49277732889624914,
+        "count": 2617.0
+    },
+    {
+        "key": "orlandosentinel.com",
+        "co2": 0.30060652776407254,
+        "count": 2479.0
+    },
+    {
+        "key": "fun.co",
+        "co2": 0.26686993771092976,
+        "count": 7816.0
+    },
+    {
+        "key": "ticketek.com.au",
+        "co2": 0.2372434905556183,
+        "count": 10995.0
+    },
+    {
+        "key": "sportinal.com",
+        "co2": 0.563136310230407,
+        "count": 1014.0
+    },
+    {
+        "key": "adverty.com",
+        "co2": 0.2914641972089351,
+        "count": 8290.0
+    },
+    {
+        "key": "britasia.tv",
+        "co2": 0.41073178485839107,
+        "count": 6546.0
+    },
+    {
+        "key": "meitusdk.com",
+        "co2": 0.26658112108113113,
+        "count": 1477.0
+    },
+    {
+        "key": "thejewishweekly.com",
+        "co2": 0.41580527478385154,
+        "count": 1360.0
+    },
+    {
+        "key": "therocketsscience.com",
+        "co2": 0.24535430087506302,
+        "count": 1669.0
+    },
+    {
+        "key": "vapebusiness.biz",
+        "co2": 1.6168163523053367,
+        "count": 1541.0
+    },
+    {
+        "key": "travelchannel.com",
+        "co2": 0.5118130518604133,
+        "count": 3094.0
+    },
+    {
+        "key": "fandomwire.com",
+        "co2": 0.20813459603978196,
+        "count": 1325.0
+    },
+    {
+        "key": "bhaskar.com",
+        "co2": 0.7641792316679902,
+        "count": 259267.0
+    },
+    {
+        "key": "blackbeautyandhair.com",
+        "co2": 0.206582163346818,
+        "count": 5536.0
+    },
+    {
+        "key": "goldcoast.com.au",
+        "co2": 0.2898727388466385,
+        "count": 1510.0
+    },
+    {
+        "key": "picksandparlays.net",
+        "co2": 0.30614836917370836,
+        "count": 31730.0
+    },
+    {
+        "key": "cardealermagazine.co.uk",
+        "co2": 0.41095945208491197,
+        "count": 1438.0
+    },
+    {
+        "key": "lookoutdata.com",
+        "co2": 0.5184617323116361,
+        "count": 2980.0
+    },
+    {
+        "key": "tennistonic.com",
+        "co2": 0.938484749440654,
+        "count": 2321.0
+    },
+    {
+        "key": "divyabhaskar.co.in",
+        "co2": 0.7545422281458578,
+        "count": 93825.0
+    },
+    {
+        "key": "www.nu.nl",
+        "co2": 0.24116476171335993,
+        "count": 1108.0
+    },
+    {
+        "key": "mamasguiderecipes.com",
+        "co2": 0.357355497926629,
+        "count": 1410.0
+    },
+    {
+        "key": "bdjobs.com",
+        "co2": 0.9200745063453818,
+        "count": 10549.0
+    },
+    {
+        "key": "guardian.ng",
+        "co2": 0.8057999890464767,
+        "count": 74313.0
+    },
+    {
+        "key": "insanelygoodrecipes.com",
+        "co2": 0.5406403770103229,
+        "count": 3420.0
+    },
+    {
+        "key": "traveller.com.au",
+        "co2": 0.25503782090930865,
+        "count": 16987.0
+    },
+    {
+        "key": "daily_puzzle.crossword",
+        "co2": 0.258997041018333,
+        "count": 17486.0
+    },
+    {
+        "key": "serving-sys.com",
+        "co2": 0.23536944485206776,
+        "count": 1511.0
+    },
+    {
+        "key": "cricbuzz-cricket-scores-news/id360466413@ios",
+        "co2": 0.2701388882465744,
+        "count": 7124.0
+    },
+    {
+        "key": "myfitnesspal/id341232718@ios",
+        "co2": 0.2672430338560007,
+        "count": 3262.0
+    },
+    {
+        "key": "the-calculator/id398129933@ios",
+        "co2": 0.28766624992293854,
+        "count": 1109.0
+    },
+    {
+        "key": "com.telstra.nrl@android",
+        "co2": 0.2615138592219179,
+        "count": 4050.0
+    },
+    {
+        "key": "pharmacy.biz",
+        "co2": 1.5228902840257974,
+        "count": 8201.0
+    },
+    {
+        "key": "wattpad/id306310789@ios",
+        "co2": 0.27115785943634946,
+        "count": 1982.0
+    },
+    {
+        "key": "gumtree-local-ads-buy-sell/id336693856@ios",
+        "co2": 0.27377702189728464,
+        "count": 2929.0
+    },
+    {
+        "key": "marktplaats.nl",
+        "co2": 0.23118064236132685,
+        "count": 6191.0
+    },
+    {
+        "key": "bartamanpatrika.com",
+        "co2": 0.5428489910242817,
+        "count": 14245.0
+    },
+    {
+        "key": "tripledot.solitaire",
+        "co2": 0.2569087217897039,
+        "count": 81552.0
+    },
+    {
+        "key": "aos.fire2048",
+        "co2": 0.2560528965106941,
+        "count": 4429.0
+    },
+    {
+        "key": "sling.com",
+        "co2": 0.5294336960636342,
+        "count": 36164.0
+    },
+    {
+        "key": "animalplanet.com",
+        "co2": 0.4787140925105036,
+        "count": 3010.0
+    },
+    {
+        "key": "investigationdiscovery.com",
+        "co2": 0.5060419968046111,
+        "count": 21250.0
+    },
+    {
+        "key": "dishanywhere.com",
+        "co2": 0.466462798070788,
+        "count": 2019.0
+    },
+    {
+        "key": "sciencechannel.com",
+        "co2": 0.48411211968895046,
+        "count": 1022.0
+    },
+    {
+        "key": "cox.com",
+        "co2": 0.608470763134943,
+        "count": 1271.0
+    },
+    {
+        "key": "blackhistorymonth.org.uk",
+        "co2": 0.35285379098272146,
+        "count": 29071.0
+    },
+    {
+        "key": "pubfinity.com",
+        "co2": 0.2533749864348362,
+        "count": 10609.0
+    },
+    {
+        "key": "mytributes.com.au",
+        "co2": 0.25506555355093846,
+        "count": 1850.0
+    },
+    {
+        "key": "carexpert.com.au",
+        "co2": 0.324647274915882,
+        "count": 67501.0
+    },
+    {
+        "key": "samaaenglish.tv",
+        "co2": 0.3641486831235694,
+        "count": 1229.0
+    },
+    {
+        "key": "vtwonen.nl",
+        "co2": 0.25029659647489827,
+        "count": 30721.0
+    },
+    {
+        "key": "vtwonen.be",
+        "co2": 0.24997849285598914,
+        "count": 3984.0
+    },
+    {
+        "key": "woman.ru",
+        "co2": 1.5011201549868656,
+        "count": 1397.0
+    },
+    {
+        "key": "kayosports.com.au",
+        "co2": 0.4445307293151452,
+        "count": 11878.0
+    },
+    {
+        "key": "zedge.android",
+        "co2": 0.2522968487248558,
+        "count": 24135.0
+    },
+    {
+        "key": "littleengine.wordpal",
+        "co2": 0.25266253929478805,
+        "count": 2875.0
+    },
+    {
+        "key": "lionstudios.mrbullet",
+        "co2": 0.24684456327593493,
+        "count": 1108.0
+    },
+    {
+        "key": "goodfood.com.au",
+        "co2": 0.25300968279182223,
+        "count": 7266.0
+    },
+    {
+        "key": "tripledot.woodoku",
+        "co2": 0.2513187620375636,
+        "count": 88145.0
+    },
+    {
+        "key": "newsexpressngr.com",
+        "co2": 0.2365956883787975,
+        "count": 7960.0
+    },
+    {
+        "key": "tempo.co",
+        "co2": 0.5983748763477438,
+        "count": 1411.0
+    },
+    {
+        "key": "racenet.com.au",
+        "co2": 0.24478198874658333,
+        "count": 29617.0
+    },
+    {
+        "key": "punters.com.au",
+        "co2": 0.23869515907732541,
+        "count": 6885.0
+    },
+    {
+        "key": "mila.bg",
+        "co2": 0.4427363773538475,
+        "count": 6616.0
+    },
+    {
+        "key": "googlesyndication.com",
+        "co2": 0.2660076507293674,
+        "count": 8143545.0
+    },
+    {
+        "key": "doubleclick.net",
+        "co2": 0.24407759204087764,
+        "count": 9844611.0
+    },
+    {
+        "key": "ampproject.net",
+        "co2": 0.2529778188848908,
+        "count": 165888.0
+    },
+    {
+        "key": "amazon-adsystem.com",
+        "co2": 0.2597712039924399,
+        "count": 2106055.0
+    },
+    {
+        "key": "googleapis.com",
+        "co2": 0.48853096998189205,
+        "count": 1903417.0
+    },
+    {
+        "key": "yimg.com",
+        "co2": 0.2633959821482415,
+        "count": 1263587.0
+    },
+    {
+        "key": "adnxs.com",
+        "co2": 0.2568565203172938,
+        "count": 399495.0
+    },
+    {
+        "key": "yahoosandbox.com",
+        "co2": 0.28797993249524606,
+        "count": 687957.0
+    },
+    {
+        "key": "inner-active.mobi",
+        "co2": 0.2681842400634,
+        "count": 1195716.0
+    },
+    {
+        "key": "pubmatic.com",
+        "co2": 0.26221784743241394,
+        "count": 895430.0
+    },
+    {
+        "key": "inmobi.com",
+        "co2": 0.2830846276950094,
+        "count": 134005.0
+    },
+    {
+        "key": "aerserv.com",
+        "co2": 0.27677456411750007,
+        "count": 3069061.0
+    },
+    {
+        "key": "taboola.com",
+        "co2": 0.8523801013565896,
+        "count": 303006.0
+    },
+    {
+        "key": "reamedia.com.au",
+        "co2": 0.26364248378473476,
+        "count": 637910.0
+    },
+    {
+        "key": "adnxs-simple.com",
+        "co2": 0.2624921977650999,
+        "count": 140827.0
+    },
+    {
+        "key": "mopub.com",
+        "co2": 0.2603189501803724,
+        "count": 394191.0
+    },
+    {
+        "key": "swm.digital",
+        "co2": 0.5150146733153275,
+        "count": 127251.0
+    },
+    {
+        "key": "hubvisor.io",
+        "co2": 0.2515381735131099,
+        "count": 47450.0
+    },
+    {
+        "key": "nexx360.io",
+        "co2": 0.24316866718657895,
+        "count": 7315.0
+    },
+    {
+        "key": "btloader.com",
+        "co2": 0.29376246797336875,
+        "count": 7028.0
+    },
+    {
+        "key": "sizmdx.com",
+        "co2": 0.2359297838498617,
+        "count": 6295.0
+    },
+    {
+        "key": "adcolony.com",
+        "co2": 0.27538667586822646,
+        "count": 19826.0
+    },
+    {
+        "key": "tapjoy.com",
+        "co2": 0.5092271397025211,
+        "count": 2491.0
+    },
+    {
+        "key": "panorama.com.al",
+        "co2": 1.9714564653759348,
+        "count": 2641.0
+    }
+]


### PR DESCRIPTION
This is a proof of concept. No design confirmed. Not to merge. 

The json file were fetch from https://github.com/good-loop/code/blob/master/dataanalysis/src/python/greendata/FetchDomainImpression.ipynb

For now if we add &generic=true at the end of any green recommendation page. The chart will show the overall domain emissions instead of the data from that brand/agency/campaign in that time period. This overall data were fetch from the script https://github.com/good-loop/code/blob/master/dataanalysis/src/python/greendata/FetchDomainImpression.ipynb, simply fetch and cleaned domain emissions from the last 90 days. 

Example link: https://localmy.good-loop.com/greendash/recommendation?emode=total&period=2023-Q2&start=2023-04-01T00%3A00%3A00.000Z&end=2023-07-01T00%3A00%3A00.000Z&tz=UTC&ft=Advertiser&brand=hANvZny7&generic=true

Questions:
- Should this generic list be turn on with a button, or I will always show up?
- Should this set of data to be in another chart, or merge it with the current data (if any)?
- The impression count of this list is the total impressions of all campaigns for the last 90 days. Doesn't seems to be reasonable to show this as impressions estimation for one brand/ agency/ campaign? 

- How often should we run this script to fetch this generic list?
- Should we save this list into ES instead of a json file in the repo? 