### PR TITLE
Green dashboard creative recommendations

### DIFF
--- a/src/js/components/impact/GLCards.jsx
+++ b/src/js/components/impact/GLCards.jsx
@@ -12,21 +12,21 @@ const MODAL_LIST_PATH = MODAL_PATH.concat("list");
 const MODAL_BACKDROP_PATH = MODAL_PATH.concat("backdrop");
 const LOADED_PATH = MODAL_PATH.concat("loaded");
 
+
 /**
  * Wraps everything into a horizontal flow. Any child with a "basis" prop will be given that priority as a percentage, e.g. basis={50}
  * 
  * @param {String} collapse the bootstrap breakpoint to break flow on
  */
 export const GLHorizontal = ({collapse, className, style, children}) => {
+	/*let uneatenSpace = 100;
+	let notSpecifiedChildCount = 0;
+	children.forEach(child => {
+		if (child.props.basis) uneatenSpace -= child.props.basis;
+		else notSpecifiedChildCount++;
+	});
 
-    /*let uneatenSpace = 100;
-    let notSpecifiedChildCount = 0;
-    children.forEach(child => {
-        if (child.props.basis) uneatenSpace -= child.props.basis;
-        else notSpecifiedChildCount++;
-    });
-
-    const autoSpacedSize = uneatenSpace / notSpecifiedChildCount;*/
+	const autoSpacedSize = uneatenSpace / notSpecifiedChildCount;*/
 
 	if (!Array.isArray(children)) children = [children];
 
@@ -39,9 +39,9 @@ export const GLHorizontal = ({collapse, className, style, children}) => {
 	</Row>
 }
 
+
 /**
  * Wraps everything into a vertical flow. Any child with a "basis" prop will be given that priority as a percentage, e.g. basis={50}
- * 
  */
 export const GLVertical = ({className, children, ...props}) => {
 	if (!Array.isArray(children)) children = [children];
@@ -54,28 +54,28 @@ export const GLVertical = ({className, children, ...props}) => {
 	</div>;
 }
 
+
 /**
  * A card content wrapper, with configurable behaviour for opening modals.
  * 
- * @param {Object} obj
- * @param {?string} obj.className className passthrough
- * @param {?boolean} obj.noPadding remove padding from the card content
- * @param {?boolean} obj.noMargin remove margin wrapper from outside the card
- * @param {?*} obj.modalContent if specified, will make card clickable to display this content in the GLModalCard specified (see below)
- * @param {?*} obj.modalTitle the title to put in the modal header
- * @param {?*} obj.modalHeader content to put in the modal header
- * @param {?*} obj.modalHeaderImg background image for the modal header
- * @param {?*} obj.modalClassName className for modal
- * @param {?Object} obj.modal package object for all the above parameters
- * @param {?String} obj.modalId the ID of the GLModalCard to use in displaying
- * @param {?Boolean} obj.modalPrioritize if this GLModalCard is opened while others are already open, force close them (they remain open by default)
- * @param {?String} obj.href make this card a link
- * @param {?} obj.children
+ * @param {object} obj
+ * @param {string} [obj.className] className passthrough
+ * @param {boolean} [obj.noPadding] remove padding from the card content
+ * @param {boolean} [obj.noMargin] remove margin wrapper from outside the card
+ * @param {*} [obj.modalContent] if specified, will make card clickable to display this content in the GLModalCard specified (see below)
+ * @param {*} [obj.modalTitle] the title to put in the modal header
+ * @param {*} [obj.modalHeader] content to put in the modal header
+ * @param {*} [obj.modalHeaderImg] background image for the modal header
+ * @param {*} [obj.modalClassName] className for modal
+ * @param {object} [obj.modal] package object for all the above parameters
+ * @param {string} [obj.modalId] the ID of the GLModalCard to use in displaying
+ * @param {boolean} [obj.modalPrioritize] if this GLModalCard is opened while others are already open, force close them (they remain open by default)
+ * @param {String} [obj.href] make this card a link
+ * @param {?} [obj.children]
  */
-export const GLCard = ({noPadding, noMargin, className, style, modalContent, modalTitle, modalId, modalHeader, modalHeaderImg, modalPrioritize, modalClassName, modal, children, href, ...props}) => {
-
+export const GLCard = ({noPadding, noMargin, className, style, modalContent, modalTitle, modalId, modalHeader, modalHeaderImg, modalPrioritize, modalClassName, modal, children, href, onClick, ...props}) => {
 	const modalObj = {
-		content: modalContent, 
+		content: modalContent,
 		title: modalTitle,
 		header: modalHeader,
 		headerImg: modalHeaderImg,
@@ -83,33 +83,38 @@ export const GLCard = ({noPadding, noMargin, className, style, modalContent, mod
 		...modal
 	};
 
-	const openModal = () => {
-		assert(modalId, "No ID specified for which overlay modal to use!");
-		
-		DataStore.setValue(MODAL_LIST_PATH.concat(modalId), modalObj);
+	const onClickCard = e => {
+		onClick && onClick(e);
+		if (modalContent) {
+			assert(modalId, "No ID specified for which overlay modal to use!");
 
-		// manually close all other modals if prioritized first
-		// Only space for one modal on mobile, so always close
-		if (modalPrioritize || isPortraitMobile()) modalToggle();
-		modalToggle(modalId);
+			DataStore.setValue(MODAL_LIST_PATH.concat(modalId), modalObj);
+			// manually close all other modals if prioritized first
+			// Only space for one modal on mobile, so always close
+			if (modalPrioritize || isPortraitMobile()) modalToggle();
+			modalToggle(modalId);
+		}
 	}
 
-	const loaded = DataStore.getValue(LOADED_PATH);
+	// const loaded = DataStore.getValue(LOADED_PATH);
 
-	let cardContents = <Card className={space("glcard", !noMargin?"m-2":"", modalContent?"glcardmodal":"", className)} onClick={modalContent && openModal} {...props}>
-		{noPadding? children
-		: <CardBody>{children}</CardBody>}
-	</Card>;
+	let cardContents = (
+		<Card className={space('glcard', !noMargin && 'm-2', modalContent && 'glcardmodal', className)} onClick={onClickCard} {...props}>
+			{noPadding ? children : <CardBody>{children}</CardBody>}
+		</Card>
+	);
 
 	if (href) {
 		cardContents = <C.A className="glcard-link" href={href} onClick={() => modalToggle()}>{cardContents}</C.A>
 	}
 
-	return noMargin ? cardContents
-	: <div className="glcard-outer" style={style}>
-		{cardContents}	
-	</div>;
+	return noMargin ? cardContents : (
+		<div className="glcard-outer" style={style}>
+			{cardContents}
+		</div>
+	);
 }
+
 
 /**
  * Opens and closes modals. If given an ID, will toggle that modal. If not, it will force close all modals.
@@ -159,7 +164,6 @@ export const markPageLoaded = (loaded) => {
  * @param {String} id 
  */
 export const GLModalCard = ({className, id}) => {
-
 	const path = MODAL_LIST_PATH.concat(id);
 	const open = DataStore.getValue(path.concat("open"));
 
@@ -192,8 +196,7 @@ export const GLModalCard = ({className, id}) => {
 				</CardBody>
 			</GLCard>
 		</div>
-	</>: null;
-
+	</> : null;
 };
 
 /**

--- a/src/js/components/pages/greendash/GreenDashUtils.jsx
+++ b/src/js/components/pages/greendash/GreenDashUtils.jsx
@@ -29,6 +29,20 @@ export const downloadIcon = (
 	</svg>
 );
 
+/** Tick graphic used in various places on recommendations page */
+export const tickSvg = (
+	<svg viewBox="0 0 100 100">
+		<path d="m25 55 13 13 35-38" fill="none" stroke="currentColor" strokeLinecap="round" strokeWidth="7"/>
+	</svg>
+);
+
+/** X graphic used in various places on recommendations page */
+export const crossSvg = (
+	<svg viewBox="0 0 100 100">
+		<g fill="none" stroke="currentColor" strokeLinecap="round" strokeWidth="7"><path d="m26 26 48 48"/><path d="m74 26-48 48"/></g>
+	</svg>
+);
+
 
 export const CO2 = <span>CO<sub>2</sub>e</span>;
 export const CO2e = <span className="co2e">CO<sub>2</sub>e</span>;

--- a/src/js/components/pages/greendash/GreenNavBar.jsx
+++ b/src/js/components/pages/greendash/GreenNavBar.jsx
@@ -14,6 +14,7 @@ import ServerIO from '../../../plumbing/ServerIO';
 import { getFilterTypeId } from './dashUtils';
 import ShareWidget, { shareThingId } from '../../../base/components/ShareWidget';
 import { modifyPage } from '../../../base/plumbing/glrouter';
+import { CO2e } from './GreenDashUtils';
 
 const A = C.A;
 
@@ -94,7 +95,7 @@ const GreenNavBar = ({active}) => {
 			</NavItem>
 			<NavItem>
 				<A className={space('nav-item', active === 'recommendation' && 'active')} href={recUrl}>
-					<div className="green-nav-icon optimisation-icon" /> Reduce
+					<div className="green-nav-icon optimisation-icon" /> <span>Reduce<br/>{CO2e}</span>
 				</A>
 			</NavItem>
 			<NavItem>

--- a/src/js/components/pages/greendash/GreenRecommendation.tsx
+++ b/src/js/components/pages/greendash/GreenRecommendation.tsx
@@ -1,418 +1,81 @@
 import React, { useEffect, useState } from 'react';
-import { Alert, Button, Card, CardBody, CardFooter, CardHeader, Col, Container, Row } from 'reactstrap';
+import { Card, Col, Container, Row } from 'reactstrap';
 import Misc from '../../../MiscOverrides';
 import { LoginWidgetEmbed } from '../../../base/components/LoginWidget';
-import NewChartWidget, { KScale } from '../../../base/components/NewChartWidget';
 import DataStore from '../../../base/plumbing/DataStore';
-import { getPeriodFromUrlParams } from '../../../base/utils/date-utils';
-import { getUrlVars, space } from '../../../base/utils/miscutils';
-import printer from '../../../base/utils/printer';
 import Login from '../../../base/youagain';
 import { GLCard } from '../../impact/GLCards';
 import GreenDashboardFilters from './GreenDashboardFilters';
-import { GreenBuckets, emissionsPerImpressions, getBasefilters, getCarbon, type BaseFilters } from './emissionscalcTs';
-import { Tick } from 'chart.js';
-import { CO2e, downloadIcon } from './GreenDashUtils';
+import { type BaseFilters } from './emissionscalcTs';
+
 import '../../../../style/GreenRecommendations.less';
+import GreenRecsPublisher from './GreenRecsPublisher';
+import GreenRecsCreative from './GreenRecsCreative';
+import { space } from '../../../base/utils/miscutils';
+import { modifyPage } from '../../../base/plumbing/glrouter';
 
-const TICKS_NUM = 600;
 
-
-interface RangeSliderProps {
-	min: number;
-	max: number;
-	step?: number;
-	defaultValue: number;
-	onChange?: Function;
-	chartObj?: {
-		chartArea: { left: number; right: number; width: number; height: number };
-	} & Object;
+export const greenRecsPath = ['widget', 'greenRecs'];
+const modePath = [...greenRecsPath, 'mode'];
+const DEFAULT_MODE = 'creative'; // vs 'publisher'
+const getOptMode = () => DataStore.getValue('location', 'path')[2];
+const setOptMode = mode => {
+	const newPath = [...DataStore.getValue(['location', 'path'])];
+	newPath[2] = mode;
+	modifyPage(newPath);
 }
 
 
-const RangeSlider: React.FC<RangeSliderProps> = ({ min, max, step, defaultValue, onChange = () => {}, chartObj, ...props }) => {
-	const [value, setValue] = useState(defaultValue);
-	useEffect(() => onChange(value), [value]); // Update value when it changes
-
-	if (!chartObj) return <></>;
-
-	const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-		setValue(parseFloat(event.target.value));
-	};
-
-	// Overlay the slider control on the chart
-	const rangeStyle = chartObj?.chartArea ? {
-		left: `${chartObj?.chartArea.left - 8}px`,
-		width: `${chartObj?.chartArea.width + 16}px`,
-		top: `${chartObj?.chartArea.height + 5}px`,
-	} : {};
-
-	// Position the value bubble: How far over (proportionally) is the slider?
-	const fraction = (value - min) / (max - min);
-	const bubbleStyle = { left: `${fraction * 100}%` };
-
-	console.warn('RANGE VALUE', value);
-
-	return <div className="cutoff-input" style={rangeStyle} {...props}>
-		<input className="w-100" type="range" min={min} max={max} step={step} value={value} onChange={handleChange} />
-		<div className="value-bubble-container">
-			<span className={space('value-bubble', fraction > 0.8 && 'to-left')} style={bubbleStyle}>{value?.toPrecision(4)} g</span>
-		</div>
-	</div>;
-};
-
-
-/**
- * Note: url param yscale=linear|logarithmic
- *
- * @param {Object} p
- * @param {GreenBuckets} p.bucketsPer1000 A DataLog breakdown of carbon emissions. e.g. [{key, co2, count}]
- * @param {Function} p.passBackChart Callback with reference to chart object - used to position range slider
- * @returns
- */
-const RecommendationChart = ({ bucketsPer1000, passBackChart }: { bucketsPer1000: GreenBuckets, passBackChart: Function }): JSX.Element | null => {
-	let logarithmic = true;
-	const yscale = DataStore.getUrlValue('yscale');
-	if (yscale) logarithmic = KScale.islogarithmic(yscale);
-
-	const [chartData, setChartData] = useState<any>();
-
-	useEffect(() => {
-		const co2s = bucketsPer1000.map((row) => row.co2 as number);
-		const maxCo2 = Math.max(...co2s);
-		const minCo2 = Math.min(...co2s);
-		const steps = (maxCo2 - minCo2) / (TICKS_NUM / 3); // How large is a tick
-
-		const scaledBuckets = bucketsPer1000.map((row) => {
-			const percentage = Math.floor(((row.co2 as number) - minCo2) / steps);
-			return { key: row.key, count: row.count, co2: row.co2, percentage };
-		});
-
-		if (!scaledBuckets) return;
-
-		const percentageBuckets: (typeof scaledBuckets)[] = Array.from({ length: TICKS_NUM / 3 }, () => []);
-		scaledBuckets.forEach((row) => {
-			const percentageKey = Math.max(row.percentage, 1) - 1;
-			if (percentageBuckets && percentageBuckets[percentageKey]) percentageBuckets[percentageKey].push(row);
-		});
-
-		const dataLabels = percentageBuckets.map((row) =>
-			row[0]?.co2 ? (row[0].co2 as number).toPrecision(2) : (percentageBuckets.indexOf(row) * steps + minCo2).toPrecision(2)
-		);
-		// const dataValues = percentageBuckets.map((row) => row.length);
-		// Weight by impressions, not count of domains
-		const dataValues = percentageBuckets.map((row) => row.reduce((acc: number, curr: any) => acc + curr.count, 0));
-
-		let chartOptions: any = {
-			title: 'Volume of publisher impressions by CO₂e emitted per impression',
-			responsive: true,
-			animation: { onComplete: ({chart}: {chart: any}) => passBackChart(chart) },
-			// see https://www.chartjs.org/docs/latest/samples/scale-options/titles.html
-			scales: {
-				x: {
-					display: true,
-					title: {
-						display: true,
-						text: 'Grams CO2e per impression',
-					},
-					ticks: {
-						stepSize: 0.25, // TODO This won't work in a bar chart - labels are chosen from the dataset labels
-						padding: 10, // make room for range slider
-					}
-				},
-				y: {
-					display: true,
-					title: {
-						display: true,
-						text: 'Impressions',
-					},
-					bounds: 'ticks',
-					ticks: { callback: (value: any, index: number, ticks: Tick[]) => {
-						if (logarithmic) {
-							return ticks[index].major ? Math.floor(value) : null; // Skip minor ticks
-						 } 
-						else {
-							return Math.floor(value); // No trailing .0 on impression count!
-						}
-					} }, 
-				},
-			},
-		};
-
-		if (logarithmic) {
-			chartOptions.scales.y.type = 'logarithmic';
-		}
-
-		setChartData({
-			type: 'bar',
-			data: {
-				labels: dataLabels,
-				datasets: [
-					{
-						label: 'Impressions',
-						data: dataValues,
-						backgroundColor: 'green',
-					},
-				],
-			},
-			options: chartOptions,
-		});
-	}, [bucketsPer1000, logarithmic]);
-
-	return chartData ? (
-		<NewChartWidget className="publisher-carbon-histogram" width={null} height={null} datalabels={null} maxy={null} {...chartData} />
-	) : (
-		<Misc.Loading text={null} pv={null} inline={null} />
-	);
-};
-
-/* Inline graphics for the tick/cross on the block/allow cards */
-const tickSvg = <svg version="1.1" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><path d="m25 55 13 13 35-38" fill="none" stroke="currentColor" strokeLinecap="round" strokeWidth="7"/></svg>;
-const crossSvg = <svg version="1.1" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><g fill="none" stroke="currentColor" strokeLinecap="round" strokeWidth="7"><path d="m26 26 48 48"/><path d="m74 26-48 48"/></g></svg>;
-
-
-const downloadCSV = (data?: string[]) => {
-	if (!data) return;
-	const csv = data.join('\n');
-	const blob = new Blob([csv], { type: 'text/csv' });
-	const url = URL.createObjectURL(blob);
-	const a = document.createElement('a');
-	a.href = url;
-	a.download = 'data.csv';
-	document.body.appendChild(a);
-	a.click();
-	document.body.removeChild(a);
-	URL.revokeObjectURL(url);
-};
-
-
-const DomainList = ({ buckets, min, max }: { buckets?: GreenBuckets; min?: number; max?: number; }): JSX.Element => {
-	if (!buckets) return <></>;
-
-	const [domains, setDomains] = useState<string[]>([]); // Filtered list of domains after applying the min/max CO2 cutoff
-	const [volumeFraction, setVolumeFraction] = useState<number>(0); // Fraction of all impressions which ran through the filtered domains
-	const [avgCO2, setAvgCO2] = useState<number>(0);
-
-	// Apply cutoffs to publisher list and generate some stats on the result
-	useEffect(() => {
-		// Apply high/low CO2 cutoff to publisher list, then sort by name
-		const filteredBuckets = buckets.filter(bkt => (
-			(max ? (bkt.co2 as number <= max) : (bkt.co2 as number > min!))
-		)).sort((a, b) => a.key > b.key ? 1 : -1);
-		setDomains(filteredBuckets.map(bkt => bkt.key as string));
-		// Calculate how many impressions the filtered publisher list contains
-		const totalImps = buckets.reduce((acc, bkt) => acc + (bkt.count as number), 0);
-		const filteredImps = filteredBuckets.reduce((acc, bkt) => acc + (bkt.count as number), 0);
-		setVolumeFraction(filteredImps / totalImps);
-		// Calculate average CO2 intensity of filtered publisher list
-		setAvgCO2(filteredBuckets.reduce((acc, bkt) => acc + (bkt.co2 as number), 0) / filteredBuckets.length);
-	}, [buckets, min, max]);
-
-	const cutoffIcon = <div className="cutoff-icon">{max ? tickSvg : crossSvg}</div>;
-
+function NotLoggedIn({}) {
 	return (
-		// @ts-ignore
-		<GLCard className={`domain-list ${max ? 'allow' : 'block'}`} noPadding>
-			<CardHeader className="domain-list-title p-2">
-				<h4 className="m-0">Suggested {max ? 'Allow' : 'Block'} List</h4>
-			</CardHeader>
-			<CardBody className="flex-column p-0">
-				<div className="cutoff-header p-3">
-					<h5 className="cutoff-label">{/* low ? 'Maximum' : 'Minimum'*/} {CO2e} emissions per impression</h5>
-					<div className="cutoff-value">
-						{cutoffIcon}
-						<span className="cutoff-number ml-3">
-							{max ? <>&le;</> : <>&gt;</>}
-							{printer.prettyNumber((max || min || 0), 3, null)} g
-						</span>
-					</div>
-				</div>
-				<div className="domain-stats flex-row mx-1 p-1">
-					<div className="domain-stat">
-						<div className="stat-name">Domains</div>
-						<div className="stat-value">{domains.length || '-'}</div>
-					</div>
-					<div className="domain-stat">
-						<div className="stat-name">Impressions</div>
-						<div className="stat-value">{printer.prettyNumber((volumeFraction * 100), 2, null)}%</div>
-					</div>
-					<div className="domain-stat">
-						<div className="stat-name">{CO2e} per</div>
-						<div className="stat-value">{printer.prettyNumber(avgCO2, 3, null)}g</div>
-					</div>
-				</div>
-				<ul className="domain-list-preview m-0 px-4">
-					{domains.map((domain, index) => (
-						<li key={index}>{domain}</li>
-					))}
-				</ul>
-			</CardBody>
-			<CardFooter className="csv-block flex-column align-items-center">
-				{cutoffIcon}
-				<div className="csv-desc my-2">
-					Use as {max ? 'an allow-list' : 'a block-list'} in your DSP
-				</div>
-				<Button className="csv-button px-3 py-1" onClick={() => downloadCSV(domains)}>Download CSV {downloadIcon}</Button>
-			</CardFooter>
-		</GLCard>
+		<Container>
+			<Card body id="green-login-card" className="m-4">
+				<Container>
+					<Row>
+						<Col className="decoration flex-center" xs="12" sm="4">
+							<img className="stamp" src="/img/green/gl-carbon-neutral.svg" />
+						</Col>
+						<Col className="form" xs="12" sm="8">
+							<img className="gl-logo my-4" src="/img/gl-logo/rectangle/logo-name.svg" />
+							<p className="text-center my-4">
+								Understand the carbon footprint of your advertising and
+								<br />
+								discover your offsetting and climate-positive successes
+							</p>
+							<LoginWidgetEmbed verb="login" canRegister={false} services={null} onLogin={null} onRegister={null} />
+						</Col>
+					</Row>
+				</Container>
+			</Card>
+		</Container>
 	);
-};
+}
 
 
-/**
- * Publisher lists
- * @returns
- */
-const PublisherListRecommendations = (): JSX.Element | null => {
-	const [co2Cutoff, setCO2Cutoff] = useState<number>(0); // CO2 grams per impression to divide allow and block list
-	const [sortedBuckets, setSortedBuckets] = useState<GreenBuckets>(); // Publisher buckets, sorted low -> high CO2
-	const [rangeProps, setRangeProps] = useState<RangeSliderProps>(); // Props object for the range input
-	const [reduction, setReduction] = useState<number>(0); // Reduction effect of allow/block list (fractional, ie 0.1 for 10%)
-	const [chartObj, setChartObj] = useState<RangeSliderProps['chartObj']>();
-
-	/* Read / set up filters */
-	interface FitlerUrlParams extends Object {
-		period?: any;
-		generic?: boolean;
-	}
-	const filterUrlParams = getUrlVars(null, null) as FitlerUrlParams;
-	const period = getPeriodFromUrlParams(filterUrlParams);
-	if (!period) return null; // Filter widget will set this on first render - allow it to update
-	filterUrlParams.period = period; // NB: period is a json object, unlike the other params
-
-	const baseFilters = getBasefilters(filterUrlParams);
-
-	let baseFiltersMessage;
-	if ('type' in baseFilters && 'message' in baseFilters) {
-		if (baseFilters.type === 'alert') {
-			baseFiltersMessage = <Alert color="info">{baseFilters.message}</Alert>;
-		}
-		if (baseFilters.type === 'loading') {
-			baseFiltersMessage = <Misc.Loading text={baseFilters.message!} pv={null} inline={null} />;
-		}
-	}
-	const baseFilterConfirmed = baseFiltersMessage ? null : (
-		{ ...baseFilters, numRows: '10000' } as unknown as BaseFilters
+function ModeLink({mode, children}) {
+	return (
+		<a className={space('mode-link', (getOptMode() === mode) && 'active')} role="button" onClick={() => setOptMode(mode)}>
+			{children}
+		</a>
 	);
+}
 
-	/* Get data and assign publishers to carbon-intensity buckets */
-	const pvChartTotal = baseFilterConfirmed ? (
-		getCarbon({ ...baseFilterConfirmed, breakdown: ['domain{"countco2":"sum"}'] })
-	) : null; // - but not until base filters are ready
 
-	console.log('filterUrlParams.generic', filterUrlParams.generic, filterUrlParams);
-
-	// Sort publisher buckets low -> high CO2
+function ModeSelect() {
+	let mode = getOptMode();
 	useEffect(() => {
-		if (filterUrlParams.generic) return;
-		if (!baseFilterConfirmed || !pvChartTotal?.resolved) return;
-		const useSampling = baseFilterConfirmed.prob && baseFilterConfirmed.prob != 0;
-		const pvChartTotalValue = useSampling ? pvChartTotal.value?.sampling : pvChartTotal.value;
-		const bucketsPer1000 = emissionsPerImpressions(pvChartTotalValue.by_domain.buckets);
-		setSortedBuckets(bucketsPer1000.slice().sort((a, b) => ((a.co2 as number) - (b.co2 as number))));
-	}, [pvChartTotal?.value]);
-
-	// TODO generic domains design TBC
-	// TODO Do we want to move this into ES and refactor this into emissionscalcTs.ts using DataStore?
-	useEffect(() => {
-		if (!filterUrlParams.generic) return;
-		console.log("Fetching generic domain emissions...");
-		fetch("../js-data/generic-domain-emissions.json")
-			.then((response) => response.json())
-			.then((data) => {
-				const jsonData = data as GreenBuckets;
-				setSortedBuckets(jsonData.slice().sort((a, b) => ((a.co2 as number) - (b.co2 as number))));
-			})
-			.catch((error) => {
-				console.error("Error:", error);
-			});
+		if (!mode) setOptMode(DEFAULT_MODE);
 	}, []);
+	if (!mode) mode = DEFAULT_MODE;
 
-	// Calculate CO2 reduction effect of chosen CO2 cutoff
-	useEffect(() => {
-		if (!sortedBuckets) return;
-		const allowBuckets = sortedBuckets.filter(bkt => bkt.co2 as number <= co2Cutoff);
-		const allowImps = allowBuckets.reduce((acc, bkt) => acc + (bkt.count as number), 0);
-		let allowWeightedAvg = allowBuckets.reduce((acc, bkt) => acc + (bkt.count as number) * (bkt.co2 as number), 0);
-		allowWeightedAvg = (allowImps > 0) ? (allowWeightedAvg / allowImps) : 0;
+	return <div className="optimisation-mode-select">
+		<ModeLink mode="publisher">Publisher Optimisations</ModeLink>
+		<ModeLink mode="creative">Creative Optimisations</ModeLink>
+	</div>;
+}
 
-		const allImps = sortedBuckets.reduce((acc, bkt) => acc + (bkt.count as number), 0);
-		let allWeightedAvg = sortedBuckets.reduce((acc, bkt) => acc + (bkt.count as number) * (bkt.co2 as number), 0);
-		allWeightedAvg = (allImps > 0) ? (allWeightedAvg / allImps) : 0;
 
-		// Fractional difference between raw weighted average and allow-list weighted average
-		setReduction((allWeightedAvg - allowWeightedAvg) / allWeightedAvg);
-	}, [sortedBuckets, co2Cutoff]);
-
-	// Init / update props for range slider input
-	useEffect(() => {
-		if (!sortedBuckets || !sortedBuckets.length) return;
-		const min = (sortedBuckets[0].co2 as number) - 0.001;
-		const max = (sortedBuckets[sortedBuckets.length - 1].co2 as number) + 0.001;
-		const step = (max - min) / TICKS_NUM;
-		setRangeProps({ min, max, step, defaultValue: (max - min) / 2, onChange: setCO2Cutoff, chartObj });
-	}, [sortedBuckets, chartObj]);
-
-	// Base filters problem / not yet loaded
-	if (baseFiltersMessage) return baseFiltersMessage;
-
-	// Haven't yet received and sorted publisher buckets
-	if (!sortedBuckets) return <Misc.Loading text={null} pv={null} inline={null} />;
-
-	return <>
-		<h6>Can you reduce your publisher-generated {CO2e} emissions?</h6>
-		{/* @ts-ignore */}
-		<GLCard className="publisher-recommendations">
-			{/* Hm: eslint + ts objects if we don't list every parameter, optional or not - but that makes for verbose code, which isn't good (time-consuming, and hides the real code) 
-			How do we get eslint to be quieter for ts? */}
-			<Row>
-				<Col xs={{size: 6, offset: 3}} className="text-center">
-					<h4 className="generator-expl">Use the slider on the graph below to generate allow and block<br/>lists based on publisher generated {CO2e}.</h4>
-				</Col>
-			</Row>
-			<Row>
-				<Col xs={3} className="px-0">
-					<DomainList buckets={sortedBuckets} max={co2Cutoff} />
-				</Col>
-				<Col xs={6} className="px-0">
-					{/* @ts-ignore */}
-					<GLCard className="generator flex-column" noPadding>
-						<CardHeader className="generator-title p-2">
-							<h4 className="m-0">Allow and Block list generator</h4>
-						</CardHeader>
-						<CardBody className="flex-column">
-							{/* We should pick the display that's best for the users.
-							<PropControl inline type="toggle" prop="scale" dflt="logarithmic" label="Chart Scale:"
-								left={{ label: 'Logarithmic', value: 'logarithmic', colour: 'primary' }}
-								right={{ label: 'Linear', value: 'linear', colour: 'primary' }}
-							/> */}
-							<div className="chart-slider-box">
-								<RecommendationChart bucketsPer1000={sortedBuckets} passBackChart={setChartObj} />
-								{rangeProps && <RangeSlider {...rangeProps} />}
-							</div>
-						</CardBody>
-						<CardFooter>
-							<h4>Estimated Reduction</h4>
-							<h4 className="reduction-number ml-4">
-								{(reduction * 100).toFixed(1)}%
-							</h4>
-						</CardFooter>
-					</GLCard>
-				</Col>
-				<Col xs={3} className="px-0">
-					<DomainList buckets={sortedBuckets} min={co2Cutoff} />
-				</Col>
-			</Row>
-			<p className="mt-2">
-				These lists are based on observed data within the current filters. <br />
-				We also have general publisher lists available for use. Please contact{' '}
-				<a href="mailto:support@good-loop.com?subject=Carbon%20reducttion%20publisher%20lists">support@good-loop.com</a> for information.
-			</p>
-		</GLCard>
-	</>;
-};
-
-const GreenRecommendation = ({ baseFilters }: { baseFilters: BaseFilters }): JSX.Element => {
+const GreenRecommendation = ({ baseFilters, ...props }: { baseFilters: BaseFilters }): JSX.Element => {
 	const [agencyIds, setAgencyIds] = useState<any[]>();
 	let agencyId = DataStore.getUrlValue('agency');
 	if (!agencyId && agencyIds?.length === 1) agencyId = agencyIds[0];
@@ -425,45 +88,17 @@ const GreenRecommendation = ({ baseFilters }: { baseFilters: BaseFilters }): JSX
 		if (userId && userId.endsWith('@pseudo')) setPseudoUser(true);
 
 		Login.getSharedWith().then((res: any) => {
-			if (!res?.cargo) {
-				setAgencyIds([]);
-				return;
-			}
-			const _agencyIds = res.cargo
-				.map((share: any) => {
-					const matches = share.item.match(/^Agency:(\w+)$/);
-					if (!matches) return null;
-					return matches[1];
-				})
-				.filter((a: any) => a);
-			setAgencyIds(_agencyIds);
+			const nextAgencyIds = [];
+			res?.cargo.forEach((share: any) => {
+				const matches = share.item.match(/^Agency:(\w+)$/);
+				if (matches) nextAgencyIds.push(matches[1]);
+			});
+			setAgencyIds(nextAgencyIds);
 		});
 	}, [Login.getId(null)]);
 
 	// Only for logged-in users!
-	if (!Login.isLoggedIn())
-		return (
-			<Container>
-				<Card body id="green-login-card" className="m-4">
-					<Container>
-						<Row>
-							<Col className="decoration flex-center" xs="12" sm="4">
-								<img className="stamp" src="/img/green/gl-carbon-neutral.svg" />
-							</Col>
-							<Col className="form" xs="12" sm="8">
-								<img className="gl-logo my-4" src="/img/gl-logo/rectangle/logo-name.svg" />
-								<p className="text-center my-4">
-									Understand the carbon footprint of your advertising and
-									<br />
-									discover your offsetting and climate-positive successes
-								</p>
-								<LoginWidgetEmbed verb="login" canRegister={false} services={null} onLogin={null} onRegister={null} />
-							</Col>
-						</Row>
-					</Container>
-				</Card>
-			</Container>
-		);
+	if (!Login.isLoggedIn()) return <NotLoggedIn />;
 
 	return (
 		<div className="green-subpage green-metrics">
@@ -471,8 +106,8 @@ const GreenRecommendation = ({ baseFilters }: { baseFilters: BaseFilters }): JSX
 				{agencyIds ? (
 					<>
 						<GreenDashboardFilters pseudoUser={pseudoUser} />
-						<PublisherListRecommendations />
-						<CreativeRecommendations />
+						<ModeSelect />
+						{(getOptMode() === 'publisher') ? <GreenRecsPublisher /> : <GreenRecsCreative />}
 					</>
 				) : (
 					<Misc.Loading text="Checking your access..." pv={null} inline={false} />
@@ -482,30 +117,5 @@ const GreenRecommendation = ({ baseFilters }: { baseFilters: BaseFilters }): JSX
 	);
 };
 
-function CreativeRecommendations() {
-	return (
-		<>{/* @ts-ignore */}
-		<GLCard>
-			<h3 className="mx-auto">Optimise Creative Files to Reduce Carbon</h3>
-			<h4>Tips</h4>
-			<p>
-				These tips can require special tools to apply. We are working on automated self-service web tools to make this easy. Meanwhile - email us and we can
-				help.
-			</p>
-			<ul>
-				<li>Use .webp format instead of .png. webp is a more modern format which can do compression and transparency.</li>
-				<li>Optimise fonts. Often a whole font will be included when just a few letters are needed.</li>
-				<li>Sometimes replacing a font with an svg can further reduce the creative weight.</li>
-				<li>Use .webm format for videos. It can get better compression.</li>
-				<li>Replace GIFs. Embedded video (e.g. .webm or .mp4) is better for animations, and .webp is better for static images.</li>
-				<li>Strip down large javascript libraries. Often a whole animation library is included when only a snippet is used.</li>
-			</ul>
-			{/* <p className="dev-only">
-				We are developing a tool for analysing ads: the <a href={'https://portal.good-loop.com/#measure'}>Low Carbon Creative Tool</a>
-			</p> */}
-		</GLCard>
-		</>
-	);
-}
 
 export default GreenRecommendation;

--- a/src/js/components/pages/greendash/GreenRecsCreative.tsx
+++ b/src/js/components/pages/greendash/GreenRecsCreative.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Alert, Button, Card, CardBody, CardFooter, CardHeader, Col, Container, Row } from 'reactstrap';
+
+
 import { GLCard } from '../../impact/GLCards';
 import { CO2e, tickSvg } from './GreenDashUtils';
 
@@ -12,7 +14,7 @@ import { modifyPage } from '../../../base/plumbing/glrouter';
 import ActionMan from '../../../plumbing/ActionMan';
 import Misc from '../../../MiscOverrides';
 import ServerIO from '../../../plumbing/ServerIO';
-import _ from 'lodash';
+
 import PageRecommendations from '../../../base/components/PageRecommendations';
 import { storedManifestForTag } from '../../../base/utils/pageAnalysisUtils';
 
@@ -76,9 +78,6 @@ function CreativeSizeOverview({ tag, manifest }) {
 
 
 function CreativeOptimisationOverview({ tag, manifest }) {
-
-	const recsList = PageRecommendations({manifest}).map(rec => <Col xs="6">{rec}</Col>);
-
 	return (
 		<GLCard noPadding noMargin className="creative-opt-overview-card">
 			<CardHeader>Optimisation Recommendations</CardHeader>
@@ -90,7 +89,7 @@ function CreativeOptimisationOverview({ tag, manifest }) {
 				</div>
 				<Container className="recs-list">
 					<Row>
-						{recsList}
+						{PageRecommendations({manifest}).map(rec => <Col xs="6">{rec}</Col>)}
 					</Row>
 				</Container>
 			</CardBody>
@@ -99,11 +98,6 @@ function CreativeOptimisationOverview({ tag, manifest }) {
 			</CardFooter>
 		</GLCard>
 	);
-}
-
-// don't mind me, just learning typescript
-type Setter<T> = {
-	(val: T): void;
 }
 
 
@@ -128,6 +122,12 @@ function AnalysePrompt({ tag }): JSX.Element {
 		
 		<Button onClick={doIt}>Analyse</Button>
 	</div>;
+}
+
+
+// don't mind me, just learning typescript
+type Setter<T> = {
+	(val: T): void;
 }
 
 
@@ -176,7 +176,10 @@ function CreativeView({ showList, setShowList }: {showList: boolean, setShowList
 }
 
 
-function GreenRecsCreative({}) {
+/**
+ * 
+ */
+function GreenRecsCreative() {
 	const [showList, setShowList] = useState(true);
 
 	return (
@@ -195,22 +198,25 @@ function GreenRecsCreative({}) {
 	);
 }
 
-const fart = <>
-	<h3 className="mx-auto">Optimise Creative Files to Reduce Carbon</h3>
-	<h4>Tips</h4>
-	<p>
-		These tips can require special tools to apply. We are working on automated self-service web tools to make this easy. Meanwhile - email us and we can
-		help.
-	</p>
-	<ul>
-		<li>Use .webp format instead of .png. webp is a more modern format which can do compression and transparency.</li>
-		<li>Optimise fonts. Often a whole font will be included when just a few letters are needed.</li>
-		<li>Sometimes replacing a font with an svg can further reduce the creative weight.</li>
-		<li>Use .webm format for videos. It can get better compression.</li>
-		<li>Replace GIFs. Embedded video (e.g. .webm or .mp4) is better for animations, and .webp is better for static images.</li>
-		<li>Strip down large javascript libraries. Often a whole animation library is included when only a snippet is used.</li>
-	</ul>
-</>;
+
+export function CreativeRecsPlaceholder() {
+	return <>
+		<h3 className="mx-auto">Optimise Creative Files to Reduce Carbon</h3>
+		<h4>Tips</h4>
+		<p>
+			These tips can require special tools to apply. We are working on automated self-service web tools to make this easy. Meanwhile - email us and we can
+			help.
+		</p>
+		<ul>
+			<li>Use .webp format instead of .png. webp is a more modern format which can do compression and transparency.</li>
+			<li>Optimise fonts. Often a whole font will be included when just a few letters are needed.</li>
+			<li>Sometimes replacing a font with an svg can further reduce the creative weight.</li>
+			<li>Use .webm format for videos. It can get better compression.</li>
+			<li>Replace GIFs. Embedded video (e.g. .webm or .mp4) is better for animations, and .webp is better for static images.</li>
+			<li>Strip down large javascript libraries. Often a whole animation library is included when only a snippet is used.</li>
+		</ul>
+	</>;
+}
 
 
 export default GreenRecsCreative;

--- a/src/js/components/pages/greendash/GreenRecsCreative.tsx
+++ b/src/js/components/pages/greendash/GreenRecsCreative.tsx
@@ -1,0 +1,205 @@
+import React, { useEffect, useState } from 'react';
+import { Alert, Button, Card, CardBody, CardFooter, CardHeader, Col, Container, Row } from 'reactstrap';
+import { GLCard } from '../../impact/GLCards';
+import { CO2e, tickSvg } from './GreenDashUtils';
+
+import C from '../../../C';
+import KStatus from '../../../base/data/KStatus';
+import ListLoad from '../../../base/components/ListLoad';
+import DataStore from '../../../base/plumbing/DataStore';
+import { space } from '../../../base/utils/miscutils';
+import { modifyPage } from '../../../base/plumbing/glrouter';
+import ActionMan from '../../../plumbing/ActionMan';
+import Misc from '../../../MiscOverrides';
+import ServerIO from '../../../plumbing/ServerIO';
+import _ from 'lodash';
+
+
+const getCreative = (): string | null => DataStore.getValue(['location', 'path'])[3];
+const setCreative = (id: string): void => {
+	const newPath = [...DataStore.getValue(['location', 'path'])];
+	newPath[3] = id;
+	modifyPage(newPath);
+};
+
+
+function CreativeListItem({item}) {
+	const active = (item.id === getCreative());
+	const setActive = () => setCreative(item.id);
+
+	return (
+		<GLCard className={space('creative-item', active && 'active')} noMargin onClick={setActive}>
+			<Misc.ImgThumbnail />
+			{item.name}
+			<div className="selected-indicator">{active && tickSvg}</div>
+		</GLCard>
+	);
+}
+
+
+function CreativeList() {
+	return (
+		<GLCard className="creative-list">
+			<div>Select a creative to view optimisation recommendations</div>
+			<div>Sort By</div>
+			<ListLoad type={C.TYPES.GreenTag} status={KStatus.PUBLISHED} hideTotal unwrapped notALink ListItem={CreativeListItem} />
+		</GLCard>
+	);
+}
+
+
+function CreativeSizeOverview({ tag }) {
+	return (
+		<GLCard noPadding noMargin className="creative-size-card">
+			<CardHeader>Your Creative Measurement</CardHeader>
+			<CardBody>
+				<div className="carbon-per-impression">
+					{CO2e} per impression based on creative size
+					<div className="number">1.1825g {CO2e}</div>
+				</div>
+				<div className="size-info">
+					<div className="bytes">
+						Creative size
+						<div className="number">{tag.weight || 999999} bytes</div>
+					</div>
+					<div className="breakdown">
+						<a role="button" onClick={() => {}}>View Breakdown</a>
+					</div>
+				</div>
+				<p>TODO thumbnail here</p>
+			</CardBody>
+		</GLCard>
+	);
+}
+
+
+function CreativeOptimisationOverview({ tag }) {
+	return (
+		<GLCard noPadding noMargin className="creative-opt-overview-card">
+			<CardHeader>Optimisation Recommendations</CardHeader>
+			<CardBody>
+				<p>Potential reduction in your creative's {CO2e}</p>
+				<div className="reduction">
+					Reduce {CO2e} by
+					<div className="number">up to XX%</div>
+				</div>
+				<div className="recs-list">
+					TODO Import recommendations generator from portal analysis page
+				</div>
+			</CardBody>
+			<CardFooter>
+				Share
+			</CardFooter>
+		</GLCard>
+	);
+}
+
+// don't mind me, just learning typescript
+type Setter<T> = {
+	(val: T): void;
+}
+
+
+/**
+ * Initiate analysis of 
+ */
+function AnalysePrompt({ tag }): JSX.Element {
+	const [analysisState, setAnalysisState] = useState<string>();
+
+	if (analysisState === 'loading') return <Misc.Loading text="Analysis in progress..." />;
+
+	const doIt = () => {
+		ServerIO.load(`${ServerIO.MEASURE_ENDPOINT}/measure`, { data: { tagId: tag.id, url: tag.creativeURL } }).then(res => {
+			// Store results where CreativeView will find them
+			if (!res.error) DataStore.setValue(['widget', 'saved-tag-measurement', tag.id], res.cargo);
+		});
+		setAnalysisState('loading');
+	};
+	
+	return <div>
+		This creative has not yet been analysed. Do it now?<br/>
+		
+		<Button onClick={doIt}>Analyse</Button>
+	</div>;
+}
+
+
+function CreativeView({ showList, setShowList }: {showList: boolean, setShowList: Setter<boolean>}): JSX.Element {
+	const tagId = getCreative();
+	if (!tagId) return <div>Select a creative from the list to get started.</div>;
+
+	const pvTag = ActionMan.getDataItem({type: C.TYPES.GreenTag, status: KStatus.PUBLISHED, id: tagId});
+
+	if (!pvTag.resolved) return <Misc.Loading text="Loading requested creative..." />;
+	if (!pvTag.value) return <Alert color="danger">Couldn't find a creative with ID <code>{tagId}</code>.</Alert>;
+	const tag = pvTag.value;
+
+	const pvManifest = DataStore.fetch(['widget', 'saved-tag-measurement', tagId], () => (
+		ServerIO.load(`${ServerIO.MEASURE_ENDPOINT}/persist/greentag_${tagId}/results.json`, { swallow: true })
+	));
+
+	if (!pvManifest.resolved) return <Misc.Loading text="Checking for saved creative manifest..." />;
+
+	return <>
+		<CardHeader>
+			<a className="pull-left expand-button" role="button" onClick={() => setShowList(!showList)}>{showList ? '⇱' : '⇲'}</a>
+			{tag.name}
+		</CardHeader>
+		<CardBody>
+			{pvManifest.value ? (
+				<Container>
+					<Row>
+						<Col xs="4">
+							<CreativeSizeOverview tag={tag} manifest={pvManifest.value} />
+						</Col>
+						<Col xs="8">
+							<CreativeOptimisationOverview tag={tag} manifest={pvManifest.value} />
+						</Col>
+					</Row>
+				</Container>
+			) : (
+				<AnalysePrompt tag={tag} />
+			)}
+		</CardBody>
+	</>;
+}
+
+
+function GreenRecsCreative({}) {
+	const [showList, setShowList] = useState(true);
+
+	return (
+			<Container fluid className="creative-recommendations">
+				<Row>
+					{showList ? (
+						<Col xs="3"><CreativeList /></Col>
+					) : null}
+					<Col xs={showList ? '9' : 12}>
+						<GLCard className="view-creative" noPadding>
+							<CreativeView showList={showList} setShowList={setShowList}/>
+						</GLCard>
+					</Col>
+				</Row>
+			</Container>
+	);
+}
+
+const fart = <>
+	<h3 className="mx-auto">Optimise Creative Files to Reduce Carbon</h3>
+	<h4>Tips</h4>
+	<p>
+		These tips can require special tools to apply. We are working on automated self-service web tools to make this easy. Meanwhile - email us and we can
+		help.
+	</p>
+	<ul>
+		<li>Use .webp format instead of .png. webp is a more modern format which can do compression and transparency.</li>
+		<li>Optimise fonts. Often a whole font will be included when just a few letters are needed.</li>
+		<li>Sometimes replacing a font with an svg can further reduce the creative weight.</li>
+		<li>Use .webm format for videos. It can get better compression.</li>
+		<li>Replace GIFs. Embedded video (e.g. .webm or .mp4) is better for animations, and .webp is better for static images.</li>
+		<li>Strip down large javascript libraries. Often a whole animation library is included when only a snippet is used.</li>
+	</ul>
+</>;
+
+
+export default GreenRecsCreative;

--- a/src/js/components/pages/greendash/GreenRecsPublisher.tsx
+++ b/src/js/components/pages/greendash/GreenRecsPublisher.tsx
@@ -1,0 +1,387 @@
+import React, { useEffect, useState } from 'react';
+import { Alert, Button, Card, CardBody, CardFooter, CardHeader, Col, Container, Row } from 'reactstrap';
+import { BaseFilters, GreenBuckets, emissionsPerImpressions, getBasefilters, getCarbon } from './emissionscalcTs';
+import { getUrlVars } from '../../../base/utils/miscutils';
+import { getPeriodFromUrlParams } from '../../../base/utils/date-utils';
+import NewChartWidget, { KScale } from '../../../base/components/NewChartWidget';
+import DataStore from '../../../base/plumbing/DataStore';
+import printer from '../../../base/utils/printer';
+import Misc from '../../../MiscOverrides';
+import { CO2e, crossSvg, downloadIcon, tickSvg } from './GreenDashUtils';
+import { GLCard } from '../../impact/GLCards';
+
+import { type BreakdownRow } from './emissionscalcTs';
+
+import '../../../../style/GreenRecommendations.less';
+import PropControl from '../../../base/components/PropControl';
+
+
+const TICKS_NUM = 600;
+
+interface ChartObj {
+	chartArea: { left: number; right: number; width: number; height: number };
+}
+
+/** Puts a PropControlRange in a container which overlays the supplied ChartJS chart */
+function CutoffSlider({ chartObj, ...props }: {chartObj?: ChartObj}): JSX.Element | null {
+	if (!chartObj) return null;
+	// Overlay the slider control on the chart
+	const rangeStyle = chartObj?.chartArea ? {
+		left: `${chartObj?.chartArea.left - 8}px`,
+		width: `${chartObj?.chartArea.width + 16}px`,
+		top: `${chartObj?.chartArea.height + 5}px`,
+	} : {};
+
+	const path = ['widget', 'GreenRecsPublisher'];
+
+	return <div className="cutoff-input" style={rangeStyle} >
+		<PropControl type="range" path={path} prop="cutoff" {...props} />
+	</div>;
+}
+
+
+/**
+ * Note: url param yscale=linear|logarithmic
+ *
+ * @param {Object} p
+ * @param {GreenBuckets} p.bucketsPer1000 A DataLog breakdown of carbon emissions. e.g. [{key, co2, count}]
+ * @param {Function} p.passBackChart Callback with reference to chart object - used to position range slider
+ * @returns
+ */
+function RecommendationChart({ bucketsPer1000, passBackChart }: { bucketsPer1000: GreenBuckets, passBackChart: Function }): JSX.Element | null {
+	let logarithmic = true;
+	const yscale = DataStore.getUrlValue('yscale');
+	if (yscale) logarithmic = KScale.islogarithmic(yscale);
+
+	const [chartData, setChartData] = useState<any>();
+
+	useEffect(() => {
+		const co2s = bucketsPer1000.map((row) => row.co2 as number);
+		const maxCo2 = Math.max(...co2s);
+		const minCo2 = Math.min(...co2s);
+		const steps = (maxCo2 - minCo2) / (TICKS_NUM / 3); // How large is a tick
+
+		const scaledBuckets = bucketsPer1000.map((row) => {
+			const percentage = Math.floor(((row.co2 as number) - minCo2) / steps);
+			return { key: row.key, count: row.count, co2: row.co2, percentage };
+		});
+
+		if (!scaledBuckets) return;
+
+		const percentageBuckets: (typeof scaledBuckets)[] = Array.from({ length: TICKS_NUM / 3 }, () => []);
+		scaledBuckets.forEach((row) => {
+			const percentageKey = Math.max(row.percentage, 1) - 1;
+			if (percentageBuckets && percentageBuckets[percentageKey]) percentageBuckets[percentageKey].push(row);
+		});
+
+		const dataLabels = percentageBuckets.map((row) =>
+			row[0]?.co2 ? (row[0].co2 as number).toPrecision(2) : (percentageBuckets.indexOf(row) * steps + minCo2).toPrecision(2)
+		);
+		// const dataValues = percentageBuckets.map((row) => row.length);
+		// Weight by impressions, not count of domains
+		const dataValues = percentageBuckets.map((row) => row.reduce((acc: number, curr: any) => acc + curr.count, 0));
+
+		let chartOptions: any = {
+			title: 'Volume of publisher impressions by CO₂e emitted per impression',
+			responsive: true,
+			animation: { onComplete: ({chart}) => passBackChart(chart) },
+			// see https://www.chartjs.org/docs/latest/samples/scale-options/titles.html
+			scales: {
+				x: {
+					display: true,
+					title: {
+						display: true,
+						text: 'Grams CO2e per impression',
+					},
+					ticks: {
+						stepSize: 0.25, // TODO This won't work in a bar chart - labels are chosen from the dataset labels
+						padding: 10, // make room for range slider
+					}
+				},
+				y: {
+					display: true,
+					title: {
+						display: true,
+						text: 'Impressions',
+					},
+					bounds: 'ticks',
+					ticks: { callback: printer.prettyInt }, // No trailing .0 on impression count!
+				},
+			},
+		};
+
+		if (logarithmic) {
+			chartOptions.scales.y.type = 'logarithmic';
+		}
+
+		setChartData({
+			type: 'bar',
+			data: {
+				labels: dataLabels,
+				datasets: [
+					{
+						label: 'Impressions',
+						data: dataValues,
+						backgroundColor: 'green',
+					},
+				],
+			},
+			options: chartOptions,
+		});
+	}, [bucketsPer1000, logarithmic]);
+
+	return chartData ? (
+		<NewChartWidget className="publisher-carbon-histogram" width={null} height={null} datalabels={null} maxy={null} {...chartData} />
+	) : (
+		<Misc.Loading text={null} pv={null} inline={null} />
+	);
+}
+
+
+const downloadCSV = (data?: string[]) => {
+	if (!data) return;
+	const csv = data.join('\n');
+	const blob = new Blob([csv], { type: 'text/csv' });
+	const url = URL.createObjectURL(blob);
+	const a = document.createElement('a');
+	a.href = url;
+	a.download = 'data.csv';
+	document.body.appendChild(a);
+	a.click();
+	document.body.removeChild(a);
+	URL.revokeObjectURL(url);
+};
+
+
+function DomainList({ buckets, min, max }: { buckets?: GreenBuckets; min?: number; max?: number; }): JSX.Element {
+	if (!buckets) return <></>;
+
+	const [domains, setDomains] = useState<string[]>([]); // Filtered list of domains after applying the min/max CO2 cutoff
+	const [volumeFraction, setVolumeFraction] = useState<number>(0); // Fraction of all impressions which ran through the filtered domains
+	const [avgCO2, setAvgCO2] = useState<number>(0);
+
+	// Apply cutoffs to publisher list and generate some stats on the result
+	useEffect(() => {
+		// Apply high/low CO2 cutoff to publisher list, then sort by name
+		const filteredBuckets = buckets.filter(bkt => (
+			(max ? (bkt.co2 as number <= max) : (bkt.co2 as number > min!))
+		)).sort((a, b) => a.key > b.key ? 1 : -1);
+		setDomains(filteredBuckets.map(bkt => bkt.key as string));
+		// Calculate how many impressions the filtered publisher list contains
+		const totalImps = buckets.reduce((acc, bkt) => acc + (bkt.count as number), 0);
+		const filteredImps = filteredBuckets.reduce((acc, bkt) => acc + (bkt.count as number), 0);
+		setVolumeFraction(filteredImps / totalImps);
+		// Calculate average CO2 intensity of filtered publisher list
+		setAvgCO2(filteredBuckets.reduce((acc, bkt) => acc + (bkt.co2 as number), 0) / filteredBuckets.length);
+	}, [buckets, min, max]);
+
+	const cutoffIcon = <div className="cutoff-icon">{max ? tickSvg : crossSvg}</div>;
+
+	return ( //@ts-ignore
+		<GLCard className={`domain-list ${max ? 'allow' : 'block'}`} noPadding>
+			<CardHeader className="domain-list-title p-2">
+				<h4 className="m-0">Suggested {max ? 'Allow' : 'Block'} List</h4>
+			</CardHeader>
+			<CardBody className="flex-column p-0">
+				<div className="cutoff-header p-3">
+					<h5 className="cutoff-label">{/* low ? 'Maximum' : 'Minimum'*/} {CO2e} emissions per impression</h5>
+					<div className="cutoff-value">
+						{cutoffIcon}
+						<span className="cutoff-number ml-3">
+							{max ? <>&le;</> : <>&gt;</>}
+							{printer.prettyNumber((max || min || 0), 3, null)} g
+						</span>
+					</div>
+				</div>
+				<div className="domain-stats flex-row mx-1 p-1">
+					<div className="domain-stat">
+						<div className="stat-name">Domains</div>
+						<div className="stat-value">{domains.length || '-'}</div>
+					</div>
+					<div className="domain-stat">
+						<div className="stat-name">Impressions</div>
+						<div className="stat-value">{printer.prettyNumber((volumeFraction * 100), 2, null)}%</div>
+					</div>
+					<div className="domain-stat">
+						<div className="stat-name">{CO2e} per</div>
+						<div className="stat-value">{printer.prettyNumber(avgCO2, 3, null)}g</div>
+					</div>
+				</div>
+				<ul className="domain-list-preview m-0 px-4">
+					{domains.map((domain, index) => (
+						<li key={index}>{domain}</li>
+					))}
+				</ul>
+			</CardBody>
+			<CardFooter className="csv-block flex-column align-items-center">
+				{cutoffIcon}
+				<div className="csv-desc my-2">
+					Use as {max ? 'an allow-list' : 'a block-list'} in your DSP
+				</div>
+				<Button className="csv-button px-3 py-1" onClick={() => downloadCSV(domains)}>Download CSV {downloadIcon}</Button>
+			</CardFooter>
+		</GLCard>
+	);
+}
+
+
+/**
+ * Publisher lists
+ * @returns
+ */
+function GreenRecsPublisher(): JSX.Element | null {
+	const [co2Cutoff, setCO2Cutoff] = useState<number>(0); // CO2 grams per impression to divide allow and block list
+	const [sortedBuckets, setSortedBuckets] = useState<GreenBuckets>(); // Publisher buckets, sorted low -> high CO2
+	const [rangeProps, setRangeProps] = useState(); // Props object for the range input
+	const [reduction, setReduction] = useState<number>(0); // Reduction effect of allow/block list (fractional, ie 0.1 for 10%)
+	const [chartObj, setChartObj] = useState();
+
+	/* Read / set up filters */
+	interface FitlerUrlParams extends Object {
+		period?: any;
+		generic?: boolean;
+	}
+	const filterUrlParams = getUrlVars(null, null) as FitlerUrlParams;
+	const period = getPeriodFromUrlParams(filterUrlParams);
+	if (!period) return null; // Filter widget will set this on first render - allow it to update
+	filterUrlParams.period = period; // NB: period is a json object, unlike the other params
+
+	const baseFilters = getBasefilters(filterUrlParams);
+
+	let baseFiltersMessage;
+	if ('type' in baseFilters && 'message' in baseFilters) {
+		if (baseFilters.type === 'alert') {
+			baseFiltersMessage = <Alert color="info">{baseFilters.message}</Alert>;
+		}
+		if (baseFilters.type === 'loading') {
+			baseFiltersMessage = <Misc.Loading text={baseFilters.message!} pv={null} inline={null} />;
+		}
+	}
+	const baseFilterConfirmed = baseFiltersMessage ? null : (
+		{ ...baseFilters, numRows: '10000' } as unknown as BaseFilters
+	);
+
+	/* Get data and assign publishers to carbon-intensity buckets */
+	const pvChartTotal = baseFilterConfirmed ? (
+		getCarbon({ ...baseFilterConfirmed, breakdown: ['domain{"countco2":"sum"}'] })
+	) : null; // - but not until base filters are ready
+
+	console.log('filterUrlParams.generic', filterUrlParams.generic, filterUrlParams);
+
+	// Sort publisher buckets low -> high CO2
+	useEffect(() => {
+		if (filterUrlParams.generic) return;
+		if (!baseFilterConfirmed || !pvChartTotal?.resolved) return;
+		const useSampling = baseFilterConfirmed.prob && baseFilterConfirmed.prob != 0;
+		const pvChartTotalValue = useSampling ? pvChartTotal.value?.sampling : pvChartTotal.value;
+		const bucketsPer1000 = emissionsPerImpressions(pvChartTotalValue.by_domain.buckets);
+		setSortedBuckets(bucketsPer1000.slice().sort((a, b) => ((a.co2 as number) - (b.co2 as number))));
+	}, [pvChartTotal?.value]);
+
+	// TODO generic domains design TBC
+	// TODO Do we want to move this into ES and refactor this into emissionscalcTs.ts using DataStore?
+	useEffect(() => {
+		if (!filterUrlParams.generic) return;
+		console.log("Fetching generic domain emissions...");
+		fetch("../js-data/generic-domain-emissions.json")
+			.then((response) => response.json())
+			.then((data) => {
+				const jsonData = data as GreenBuckets;
+				setSortedBuckets(jsonData.slice().sort((a, b) => ((a.co2 as number) - (b.co2 as number))));
+			})
+			.catch((error) => {
+				console.error("Error:", error);
+			});
+	}, []);
+
+
+	// Calculate CO2 reduction effect of chosen CO2 cutoff
+	useEffect(() => {
+		if (!sortedBuckets) return;
+		const allowBuckets = sortedBuckets.filter(bkt => bkt.co2 as number <= co2Cutoff);
+		const allowImps = allowBuckets.reduce((acc, bkt) => acc + (bkt.count as number), 0);
+		let allowWeightedAvg = allowBuckets.reduce((acc, bkt) => acc + (bkt.count as number) * (bkt.co2 as number), 0);
+		allowWeightedAvg = (allowImps > 0) ? (allowWeightedAvg / allowImps) : 0;
+
+		const allImps = sortedBuckets.reduce((acc, bkt) => acc + (bkt.count as number), 0);
+		let allWeightedAvg = sortedBuckets.reduce((acc, bkt) => acc + (bkt.count as number) * (bkt.co2 as number), 0);
+		allWeightedAvg = (allImps > 0) ? (allWeightedAvg / allImps) : 0;
+
+		// Fractional difference between raw weighted average and allow-list weighted average
+		setReduction((allWeightedAvg - allowWeightedAvg) / allWeightedAvg);
+	}, [sortedBuckets, co2Cutoff]);
+
+	// Init / update props for range slider input
+	useEffect(() => {
+		if (!sortedBuckets || !sortedBuckets.length) return;
+		const min = (sortedBuckets[0].co2 as number) - 0.001;
+		const max = (sortedBuckets[sortedBuckets.length - 1].co2 as number) + 0.001;
+		const step = (max - min) / TICKS_NUM;
+		const onChangeInstant = (event: InputEvent) => {
+			console.log('slider moved', new Date().getTime() % 1000);
+			setCO2Cutoff(event.target.value);
+		};
+		setRangeProps({ min, max, step, dflt: (max - min) / 2, onChangeInstant, chartObj });
+	}, [sortedBuckets, chartObj]);
+
+	// Base filters problem / not yet loaded
+	if (baseFiltersMessage) return baseFiltersMessage;
+
+	// Haven't yet received and sorted publisher buckets
+	if (!sortedBuckets) return <Misc.Loading text={null} pv={null} inline={null} />;
+
+	return <>
+		<h6>Can you reduce your publisher-generated {CO2e} emissions?</h6>
+		{/* @ts-ignore */}
+		<GLCard className="publisher-recommendations">
+			{/* Hm: eslint + ts objects if we don't list every parameter, optional or not - but that makes for verbose code, which isn't good (time-consuming, and hides the real code) 
+			How do we get eslint to be quieter for ts? */}
+			<Row>
+				<Col xs={{size: 6, offset: 3}} className="text-center">
+					<h4 className="generator-expl">Use the slider on the graph below to generate allow and block<br/>lists based on publisher generated {CO2e}.</h4>
+				</Col>
+			</Row>
+			<Row>
+				<Col xs={3} className="px-0">
+					<DomainList buckets={sortedBuckets} max={co2Cutoff} />
+				</Col>
+				<Col xs={6} className="px-0">
+					{/* @ts-ignore */}
+					<GLCard className="generator flex-column" noPadding>
+						<CardHeader className="generator-title p-2">
+							<h4 className="m-0">Allow and Block list generator</h4>
+						</CardHeader>
+						<CardBody className="flex-column">
+							{/* We should pick the display that's best for the users.
+							<PropControl inline type="toggle" prop="scale" dflt="logarithmic" label="Chart Scale:"
+								left={{ label: 'Logarithmic', value: 'logarithmic', colour: 'primary' }}
+								right={{ label: 'Linear', value: 'linear', colour: 'primary' }}
+							/> */}
+							<div className="chart-slider-box">
+								<RecommendationChart bucketsPer1000={sortedBuckets} passBackChart={setChartObj} />
+								{rangeProps && <CutoffSlider {...rangeProps} />}
+							</div>
+						</CardBody>
+						<CardFooter>
+							<h4>Estimated Reduction</h4>
+							<h4 className="reduction-number ml-4">
+								{(reduction * 100).toFixed(1)}%
+							</h4>
+						</CardFooter>
+					</GLCard>
+				</Col>
+				<Col xs={3} className="px-0">
+					<DomainList buckets={sortedBuckets} min={co2Cutoff} />
+				</Col>
+			</Row>
+			<p className="mt-2">
+				These lists are based on observed data within the current filters. <br />
+				We also have general publisher lists available for use. Please contact{' '}
+				<a href="mailto:support@good-loop.com?subject=Carbon%20reducttion%20publisher%20lists">support@good-loop.com</a> for information.
+			</p>
+		</GLCard>
+	</>;
+}
+
+
+export default GreenRecsPublisher;

--- a/src/style/GreenRecommendations.less
+++ b/src/style/GreenRecommendations.less
@@ -1,10 +1,29 @@
+@gat-light-green: #7eb58e;
+@gat-deep-green: #2f5d64;
+@gat-grey: #707070;
+@gat-palebg: #eff3f5;
+@gat-palerbg: #f6f8f9;
+
+#greendash .optimisation-mode-select {
+	font-size: 1.25rem;
+	border-bottom: 1px solid silver;
+	margin-bottom: 0.5em;
+	.mode-link {
+		padding: 0.25em;
+		display: inline-block;
+		&:not(:last-child) {
+			margin-right: 2em;
+		}
+		&.active {
+			font-weight: 600;
+			color: @gat-deep-green;
+			border-bottom: 0.25em solid currentColor;
+		}
+	}
+}
+
+
 #greendash .publisher-recommendations {
-
-	@allow-card-color: #7eb58e;
-	@block-card-color: #707070;
-	@generator-card-color: #2f5d64;
-	@footer-color: #eff3f5;
-
 	/* Common styling for all 3 cards */
 	.domain-list, .generator {
 		height: 36rem;
@@ -17,7 +36,7 @@
 		}
 		.card-footer {
 			border-top: none;
-			background-color: @footer-color;
+			background-color: @gat-palebg;
 			height: 8rem;
 		}
 	}
@@ -25,11 +44,11 @@
 	/* The centre card with the generator controls */
 	.generator-expl {
 		line-height: 1.5;
-		color: @generator-card-color;
+		color: @gat-deep-green;
 	}
 	.generator {
 		.card-header {
-			background-color: @generator-card-color;
+			background-color: @gat-deep-green;
 		}
 		.card-footer {
 			display: flex;
@@ -52,19 +71,15 @@
 				// Display a bubble with exact value next to the slider
 				.value-bubble {
 					position: absolute;
-					background-color: @footer-color;
+					background-color: @gat-palebg;
 					border: 1px solid silver;
 					border-radius: 0.5rem;
 					padding: 0.5rem 0.75rem;
 					margin-left: 0.75rem;
+					margin-right: 0.75rem;
 					margin-top: -0.75rem;
 					white-space: nowrap;
 					font-weight: 600;
-					// Flip to left if close to right edge
-					&.to-left {
-						margin-left: -0.75rem;
-						transform: translateX(-100%);
-					}
 				}
 				// Because the distance between the left and right extremes of the slider centre is smaller than the overall track size,
 				// we have to adjust the range over which the slider-value bubble travels left to right
@@ -145,24 +160,121 @@
 
 		&.allow {
 			.domain-list-title, .cutoff-icon {
-				background-color: @allow-card-color;
+				background-color: @gat-light-green;
 			}
 			.cutoff-number, .csv-desc, .csv-button {
-				color: @allow-card-color !important; // important needed to override button rules
+				color: @gat-light-green !important; // important needed to override button rules
 			}
 			.domain-stats, .csv-button {
-				border-color: @allow-card-color;
+				border-color: @gat-light-green;
 			}
 		}
 		&.block {
 			.domain-list-title, .cutoff-icon {
-				background-color: @block-card-color;
+				background-color: @gat-grey;
 			}
 			.cutoff-number, .csv-desc, .csv-button {
-				color: @block-card-color !important; // important needed to override button rules
+				color: @gat-grey !important; // important needed to override button rules
 			}
 			.domain-stats, .csv-button {
-				border-color: @block-card-color;
+				border-color: @gat-grey;
+			}
+		}
+	}
+}
+
+#greendash .creative-recommendations {
+	.creative-list {
+		background-color: @gat-palebg;
+		.creative-item {
+			background-color: @gat-palerbg;
+			.card-body {
+				display: flex;
+				justify-content: space-between;
+			}
+			
+			.selected-indicator {
+				display: inline-block;
+				width: 2em;
+				height: 2em;
+				border: 1px solid silver;
+				border-radius: 50%;
+			}
+
+			&.active {
+				.selected-indicator {
+					border: none;
+					color: white;
+					background-color: @gat-deep-green;
+				}
+			}
+		}
+	}
+
+	.view-creative {
+		.card-header {
+			font-weight: 600;
+		}
+		> .card-header {
+			background-color: @gat-palebg;
+			font-size: 125%;
+			text-align: center;
+		}
+		.expand-button {
+			font-size: 175%;
+			line-height: 1;
+		}
+		.creative-size-card {
+			color: @gat-deep-green;
+			> .card-header {
+				background-color: @gat-deep-green;
+				color: white;
+				text-transform: uppercase;
+				text-align: center;
+			}
+			.carbon-per-impression {
+				text-align: center;
+				.number {
+					font-size: 175%;
+					font-weight: 600;
+				}
+			}
+			.size-info {
+				padding: 0.5em 0;
+				display: flex;
+				border: 0.25em solid @gat-deep-green;
+				border-left: none;
+				border-right: none;
+				> * {
+					flex-basis: 50%;
+					padding: 0.25em;
+				}
+				.bytes {
+					border-right: 1px solid silver;
+					.number {
+						color: black;
+					}
+				}
+			}
+		}
+		.creative-opt-overview-card {
+			color: @gat-deep-green;
+			> .card-header {
+				text-transform: uppercase;
+				text-align: center;
+			}
+			.card-header {
+				background-color: @gat-light-green;
+				color: white;
+			}
+			.reduction {
+				text-align: center;
+				color: @gat-light-green;
+				font-weight: 600;
+				font-size: 150%;
+				.number {
+					font-size: 200%;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
- Publisher recs and creative recs are on separate sub-pages with a switcher at the top per Fiona's design
- Publisher recs pulled out to its own file & now uses new PropControlRange component (TODO: very slightly more chuggy when sliding through dense parts of the graph)
- Creative recs page can load existing analysis files & invoke MeasureServlet to execute new ones, but still needs breakdown widgets & recommendations engine pulled from the non-client-facing page