### PR TITLE
Big cleanup of AdvertsCatalogue

### DIFF
--- a/src/js/components/campaignpage/AdvertsCatalogue.jsx
+++ b/src/js/components/campaignpage/AdvertsCatalogue.jsx
@@ -53,18 +53,20 @@ const AdvertsCatalogue = ({ ads, noPreviews, className, captions = true }) => {
 	// Multiple ads, previews OK = show preview row
 	const multiple = ads.length > 1;
 	const showPreviews = multiple && !noPreviews;
+	// If preview carousel is being rendered, conditionally hide the individual-ad indicator buttons.
+	const indicatorClasses = showPreviews && 'd-flex d-md-none';
 
 	return (
 		<div className={space('ads-catalogue', showPreviews && 'has-previews', multiple && 'multiple', className)}>
 			<Carousel
+				className="main-carousel"
 				activeIndex={activeIndex}
 				next={next}
 				previous={previous}
 				interval={false}
-				className="main-carousel"
 			>
 				{multiple && <CarouselIndicators
-					className="d-flex d-md-none"
+					className={space('single-ad-indicators', indicatorClasses)}
 					items={carouselSlides}
 					activeIndex={activeIndex}
 					onClickHandler={goToIndex}
@@ -89,17 +91,7 @@ const AdPreviewCarousel = ({ ads, selectedIndex, setSelected }) => {
 	const [page, setPage] = useState(0);
 	const [animating, setAnimating] = useState(false);
 
-	const pages = Math.ceil(ads.length / PAGE_SIZE);
 
-	// Back/forward functions
-	const goToPage = (newPage) => {
-		if (animating) return;
-		newPage = newPage % pages;
-		if (newPage < 0) newPage += pages;
-		setPage(newPage);
-	};
-	const next = () => goToPage(page + 1);
-	const previous = () => goToPage(page - 1);
 
 	// Keep previews page synced with selected advert (eg if user uses upper arrows to go off end of page)
 	useEffect(() => {
@@ -117,28 +109,41 @@ const AdPreviewCarousel = ({ ads, selectedIndex, setSelected }) => {
 		/>
 	));
 
-	// ...and distribute them across the pages
+	// ...and distribute them across the pages.
 	const pageProps = { onExiting: () => setAnimating(true), onExited: () => setAnimating(false), className: 'preview-page' };
 	const carouselSlides = range(0, ads.length, PAGE_SIZE).map(pageStart => (
-		 <CarouselItem key={pageStart} {...pageProps}>
+		<CarouselItem key={pageStart} {...pageProps}>
 				<div className="preview-card-positioner">
 					{adPreviews.slice(pageStart, pageStart + PAGE_SIZE)}
 				</div>
 		</CarouselItem>
 	));
 
-	// Leave out controls if there's only one page
+	// How many pages, after processing all ads?
+	const pages = carouselSlides.length;
+	// Leave out controls if there's only one page.
 	const multiple = pages > 1;
+
+	// Back/forward functions
+	const goToPage = (newPage) => {
+		if (animating) return;
+		newPage = newPage % pages;
+		if (newPage < 0) newPage += pages;
+		setPage(newPage);
+	};
+	const next = () => goToPage(page + 1);
+	const previous = () => goToPage(page - 1);
 
 	return (
 		<Carousel
+			className="preview-carousel d-md-block d-none"
 			activeIndex={page}
 			next={next}
 			previous={previous}
 			interval={false}
-			className="preview-carousel d-md-block d-none"
 		>
 			{multiple && <CarouselIndicators
+				className="ad-page-indicators"
 				items={carouselSlides}
 				activeIndex={page}
 				onClickHandler={goToPage}

--- a/src/js/components/campaignpage/AdvertsCatalogue.jsx
+++ b/src/js/components/campaignpage/AdvertsCatalogue.jsx
@@ -190,15 +190,13 @@ const AdCard = ({ ad, active, isMain, onClick: _onClick, selected = false }) => 
 	// Record the aspect ratio of the maximum available size
 	useEffect(() => {
 		if (!active) return; // Inactive items have contents hidden, don't try to measure
-		if (maxAspect) { // sizer changed, invalidate previous recording
-			setMaxAspect(null);
+		if (!sizer) {
+			if (maxAspect) setMaxAspect(null); // sizer changed, invalidate previous measurement
 			return;
 		}
-		if (!sizer) return;
 		const { width, height } = sizer.getBoundingClientRect();
 		setMaxAspect(width / height);
 	}, [sizer, keepLive]);
-	// preview cards: check size first time they flip to "active"
 
 	// Main cards revert to placeholders when they become inactive, so running ads get stopped
 	// Preview cards stick, so they don't have to reload again on every scroll
@@ -226,7 +224,7 @@ const AdCard = ({ ad, active, isMain, onClick: _onClick, selected = false }) => 
 
 	return <div className={space('ad-sizer', ...sizerClasses)} onClick={onClick} ref={setSizer}>
 		{isMain ? <AdPortalLink ad={ad} /> : null}
-		{(active || keepLive) ? <GoodLoopUnit {...unitProps} /> : placeholder}
+		{keepLive ? <GoodLoopUnit {...unitProps} /> : placeholder}
 		{/* onClick && <div className="click-catcher" onClick={e => {stopEvent(e); onClick(e);}} /> */}
 	</div>;
 };

--- a/src/js/components/campaignpage/CampaignPage.jsx
+++ b/src/js/components/campaignpage/CampaignPage.jsx
@@ -328,7 +328,7 @@ const CampaignPage = () => {
 					setCtaModalOpen={setCtaModalOpen}
 					/>
 
-				{isLanding ? null : (<>
+				{!isLanding && <Container>
 					<AdvertsCatalogue
 						campaign={campaign}
 						ads={ads}
@@ -340,7 +340,7 @@ const CampaignPage = () => {
 						setCtaModalOpen={setCtaModalOpen}
 						className="my-5"
 					/>
-				</>)}
+				</Container>}
 
 				{charities.length !== 0 && 
 					<CharitiesSection charities={charities} donation4charity={donation4charity} campaign={campaign} setCtaModalOpen={setCtaModalOpen}/>

--- a/src/js/components/impact/ImpactOverviewPage.jsx
+++ b/src/js/components/impact/ImpactOverviewPage.jsx
@@ -61,7 +61,7 @@ export class ImpactFilters {
  * 
  * @returns {JSX.Element}
  */
-function IOPFirstHalf({ mainItem, wtdAds, tadgAds, brand, campaign, charities, impactDebits, totalString, mainLogo }) {
+function IOPFirstHalf({ mainItem, brand, campaign, charities, impactDebits, totalString, mainLogo }) {
 	return <GLVertical>
 		{/* top left corner - both top corners with basis 60 to line up into grid pattern */}
 		<GLCard basis={campaign ? 80 : 60} className="hero-card">
@@ -83,10 +83,6 @@ function IOPFirstHalf({ mainItem, wtdAds, tadgAds, brand, campaign, charities, i
 		{campaign ? (
 			<CampaignCharityDisplay charities={charities} impactDebits={impactDebits}/>
 		) : (
-			/*<GLHorizontal>
-				<WTDCard ads={wtdAds} brand={brand} charities={charities} impactDebits={impactDebits} />
-				<TADGCard ads={tadgAds} brand={brand} charities={charities} impactDebits={impactDebits} />
-			</GLHorizontal>*/
 			// Can't have in set - or CommonDivision wrapper messes up. Can't think of fix so just shove contents here for now
 			<CharitiesCardSet charities={charities} impactDebits={impactDebits} mainItem={mainItem}/>
 		)}
@@ -211,14 +207,12 @@ function OffsetsCard() {
  * 
  * @returns {JSX.Element}
  */
-function AdsCatalogueCard({ ads, campaign, unwrap, noPreviews }) {
+function AdsCatalogueCard({ ads, campaign, unwrap }) {
 	let showAds = ads.filter(ad => !Advert.hideFromShowcase(ad));
 
+	// Just show the first ad - no controls etc needed, as clicking will open the modal
 	const content = showAds.length ? (
-		<AdvertsCatalogue
-			ads={showAds}
-			noPreviews
-		/>
+		<AdvertsCatalogue ads={[showAds[0]]} noPreviews />
 	) : (
 		<h3>No ads yet!</h3>
 	);
@@ -229,7 +223,7 @@ function AdsCatalogueCard({ ads, campaign, unwrap, noPreviews }) {
 		basis: (campaign && 70),
 		className: 'ads-catalogue-card',
 		modalId: 'full-page',
-		modalContent: <AdvertsCatalogue ads={showAds} unwrap />,
+		modalContent: <AdvertsCatalogue ads={showAds} />,
 		modalClassName: 'ads-catalogue-modal',
 	};
 

--- a/src/style/AdvertsCatalogue.less
+++ b/src/style/AdvertsCatalogue.less
@@ -1,0 +1,136 @@
+.ads-catalogue {
+	position: relative; // Enable as height reference for main/preview carousels
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+
+	// Position dev link out of the way-ish
+	.main-ad {
+		position: relative;
+		.dev-link {
+			position: absolute;
+			top: 0;
+			right: 0;
+			z-index: 999;
+		}
+	}
+
+	.main-carousel {
+		width: 100%;
+	}
+
+	.preview-carousel {
+		width: 100%;
+		height: 12.5%;
+		.carousel-inner {
+			padding: 0.25em 0; // Leave room for the outline on the selected preview-item
+		}
+	}
+
+	// Distribute height between main and preview...
+	&.multiple .main-carousel {
+		max-height: 90%; // Leave room for page indicator
+	}
+	
+	&.has-previews .main-carousel {
+		max-height: 80%; // Leave room for previews if present
+		margin-bottom: 1%;
+	}
+
+
+
+	// Leave some side room for buttons
+
+	&.multiple {
+		.main-carousel, .preview-carousel {
+			// Shrink inner, not outer, as we want the buttons to use the extra room at the sides
+			.carousel-inner {
+				max-width: 85%;
+				margin: auto;
+			}
+		}
+	}
+
+	// Cascade height down from .carousel to .carousel-inner to .carousel-item
+	// Relative heights on .carousel-item are basically impossible due to the number of ancestors with position: relative acting as false references
+	.carousel-inner, .carousel-item {
+		height: 100%;
+	}
+
+	// Arrange the ads in preview rows
+	.preview-card-positioner {
+		display: flex;
+		justify-content: center;
+		height: 100%;
+	}
+
+	// Clicks should ignore ads inside preview cards & just get caught by card's onClick
+	.preview-ad {
+		cursor: pointer; // signal clickable
+		.goodLoopContainer {
+			pointer-events: none;
+		}
+		border-radius: 0.25em;
+		transition: outline 0.2s linear;
+		&.selected {
+			outline: 0.2em solid white;
+			// border-color: rgba(255, 255, 255, 0.85);
+		}
+	}
+
+	// Adunits need to receive clicks, so controls shouldn't overlap them
+	.carousel-control-next, .carousel-control-prev {
+		width: 7.5%; // half of BS standard, complements max-width 85% for carousels
+	}
+
+	// The fixed-aspect boxes which hold the GL units
+	.ad-sizer {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		
+		width: 100%;
+		height: 100%;
+		// currently probing available size, don't show children
+		&.hide-contents > * {
+			display: none;
+		}
+		&.fix-width {
+			height: unset;
+		}
+		&.fix-height {
+			width: unset;
+		}
+		&.main-ad {
+			margin: auto; // centre in full-width .carousel-item
+		}
+		&.preview-ad {
+			&:not(:first-child) {
+				margin-left: 5%;
+			}
+		}
+		&.landscape {
+			aspect-ratio: 16/9;
+		}
+		&.portrait {
+			aspect-ratio: 9/16;
+		}
+	}
+	
+	// Don't overlap the indicators with the clickable previews
+	.carousel-indicators {
+		bottom: unset;
+		top: 100%;
+	}
+
+	// Invisible element to stop "jump to this" clicks on previews also interacting with the ad inside
+	.click-catcher {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		cursor: pointer;
+	}
+}

--- a/src/style/CampaignPage.less
+++ b/src/style/CampaignPage.less
@@ -567,9 +567,17 @@
 				}
 			}
 		}
-	}
+	} // ./impact-hub-splash
 
-	// ./impact-hub-splash
+	// Advert catalogue: give explicit but viewport-limited height so dynamic sizing of ads can work
+	.ads-catalogue {
+		height: 35rem;
+		max-height: 65vh;
+		// white background = dark highlight on selected preview
+		.preview-ad.selected {
+			outline-color: rgba(0, 0, 0, 0.75);
+		}
+	}
 
 	h1,
 	h2 {

--- a/src/style/CampaignPage.less
+++ b/src/style/CampaignPage.less
@@ -700,27 +700,6 @@
 		}
 	}
 
-	.pointer-wrapper {
-		cursor: pointer;
-
-		.ad-prev {
-			pointer-events: none;
-			overflow: hidden;
-			border: 5px solid transparent;
-			transition: 0.2s;
-		}
-
-		&.selected {
-			cursor: default;
-
-			.ad-prev {
-				border-radius: 5px;
-				border: 5px solid red;
-				transition: 0.2s;
-			}
-		}
-	}
-
 	.charity-quote {
 		background-color: white;
 		box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.2);

--- a/src/style/ImpactB2C.less
+++ b/src/style/ImpactB2C.less
@@ -1018,12 +1018,12 @@
 			}
 		}
 
+		// The ad preview container - phone frame with leaves
 		.ad-deco-cont {
 			position: relative;
 			height: fit-content;
 			width: 100em; // Define width as always being 100em & size children in em to maintain proportions...
 			font-size: 0.45vw; // ...and set font size to change overall size
-
 
 			.spotlight-ad {
 				position: relative;
@@ -1031,36 +1031,28 @@
 
 				// Black background for screen & sizer for ad content
 				.phone-screen {
-					pointer-events: none; // sorted in front of adunit, shouldn't catch clicks/taps
 					position: absolute;
 					background: black;
 					top: 3.5em;
 					bottom: 3.5em;
 					left: 3.3em;
 					right: 3.3em;
-					padding: 1em; // push content in to keep clear notch and round corners
 				}
-
-				// Override carousel / GoodLoopUnit defaults (TODO ads carousel should not do this)
-				.main-ad {
-					max-width: unset !important;
-					width: 100%;
-					height: 100%;
-				}
-				.ad-unit-outer {
-					height: 100%;
-					margin: auto; // centre block element horizontally
-					aspect-ratio: calc(16/9);
-				}
-				.goodLoopContainer {
-					max-width: unset !important;
-					height: 100% !important;
-				}
-				// /Override carousel defaults
 				
 				.phone-container {
+					pointer-events: none; // sorted in front of adunit, shouldn't catch clicks/taps
 					position: relative;
 					z-index: 10;
+					// Minor hack: ensure frame image has correct size before it loads,
+					// so carousel inside can correctly measure available space
+					width: 100%;
+					aspect-ratio: 265/150; // px sizing of phone frame SVG
+				}
+				.ads-catalogue {
+					height: 100%; // so contents will be vertically centred in phone frame
+				}
+				.main-carousel {
+					width: 90%; // don't let corners/edges get cut off by screen rounding or notch
 				}
 			}
 
@@ -1097,7 +1089,7 @@
 					left: 0;
 				}
 			}
-		}
+		} // /.ad-deco-cont
 
 		// Narrower than e.g. small laptop screens = stack desc + ad preview vertically
 		@media (max-width: 1080px) {

--- a/src/style/ImpactOverview.less
+++ b/src/style/ImpactOverview.less
@@ -215,30 +215,13 @@
 	}
 
 	.ads-catalogue-card {
-		.ad-unit-outer {
-			pointer-events: none;
-		}
-		// HACK some ugly brute force to make the ad fill the space its given
+		height: 15rem; // 
 		.ads-catalogue {
+			pointer-events: none; // Contents not clickable - click will show modal
+		}
+		.ads-catalogue, .main-carousel {
 			height: 100%;
-			padding: 0;
-			.carousel {
-				height: 100%;
-				.carousel-inner {
-					height: 100%;
-					.carousel-item {
-						height: 100%;
-						.main-ad {
-							height: 100%;
-							max-width: 100% !important;
-							display: flex;
-							flex-direction: column;
-							justify-content: center;
-							align-items: stretch;
-						}
-					}
-				}
-			}
+			width: 100%;
 		}
 	}
 
@@ -352,9 +335,20 @@
 		}
 
 		&.ads-catalogue-modal {
-
-			.preview-carousel {
-				height: 20rem;
+			max-height: calc(100vh - 5rem); // no scrolling, even if main card layout scrolls
+			// Let carousel overlap header for space...
+			.card-header {
+				position: absolute;
+				z-index: 2;
+			}
+			// ...but make sure the X button stays in front
+			.card-body {
+				z-index: 1;
+			}
+			
+			// Have catalogue explicitly fill card height
+			.ads-catalogue {
+				height: 100%;
 			}
 
 			.glcard {
@@ -362,26 +356,6 @@
 
 				.goodLoopContainer {
 					background-color: black;
-				}
-
-				.pointer-wrapper {
-					cursor: pointer;
-			
-					.ad-prev {
-						pointer-events: none;
-						overflow: hidden;
-						border: 5px solid transparent;
-						transition: 0.2s;
-					}
-			
-					&.selected {
-						cursor: default;
-						.ad-prev {
-							border-radius: 5px;
-							border: 5px solid red;
-							transition: 0.2s;
-						}
-					}
 				}
 			}
 		}


### PR DESCRIPTION
NB this isn't fixing show-stopping bugs, so don't worry about scrambling to get it fully tested for release. Just getting my local git cleaned up.

A little more complicated in some ways (now probes its container for available space & sets some utility classes to fix aspect ratio), overall should be simpler & more flexible.

Should now show at the right size in most contexts - places to test, off the top of my head:
- Impact Overview: the small preview card & the full-window modal
- Impact Stories: the ad preview in the phone frame
- Legacy campaign pages