### PR TITLE
Green recommendations: fix recommendation list caching

### DIFF
--- a/src/js/components/pages/greendash/GreenRecsCreative.tsx
+++ b/src/js/components/pages/greendash/GreenRecsCreative.tsx
@@ -195,20 +195,19 @@ function CreativeOptimisationControls() {
 
 
 function CreativeOptimisationOverview({ tag, manifest }): JSX.Element {
-	const path = processedRecsPath({tag}, manifest);
-	// ??what data "type" is recommendations??
-	const recommendations = DataStore.getValue(path);
-
-	const regenerate = () => generateRecommendations(manifest, path);
+	// Get the recommendations list - this is an array of Transfer objects augmented with replacement candidates
+	// eg recommendations[0] = { url: "https://etc", bytes: 150000, optUrl: "[recompressed file]", optBytes: 75000 }
+	const prPath = processedRecsPath({tag}, manifest);
+	const recommendations = DataStore.getValue(prPath);
 
 	// Hard-set initial values for options and force an update
-	useEffect(() => DataStore.setValue(RECS_OPTIONS_PATH, { noWebp: false, retinaMultiplier: 1 }), []);
+	useEffect(() => DataStore.setValue(RECS_OPTIONS_PATH, { noWebp: false, retinaMultiplier: '1' }), []);
 
-	// If there was no recommendations list in DataStore for the current tag/manifest combo, generate now.
+	// If there was no recommendations list in DataStore for the current tag/manifest/options combo, generate now.
 	useEffect(() => {
 		if (!DataStore.getValue(RECS_OPTIONS_PATH)) return; // Don't generate until default options are set
-		if (manifest && !recommendations) regenerate();
-	}, [recommendations, ...path]);
+		if (manifest && !recommendations) generateRecommendations(manifest, prPath);
+	}, [recommendations, prPath]);
 
 	const recCards = recommendations?.filter(spec => spec.optBytes < spec.bytes)
 	.map(spec => (


### PR DESCRIPTION
Recs lists are cached under a path derived from the analysed tag, the analysis manifest timestamp, and the option-set (retina, webp etc) they were generated under - previous code had some dodgy scoping that meant freshly-generated lists were stored under a stale path, so you'd see weird results when clicking around options.