### PR TITLE
Creative recommendations: fix caching paths

### DIFF
--- a/src/style/GreenRecommendations.less
+++ b/src/style/GreenRecommendations.less
@@ -307,6 +307,9 @@
 				background-color: @gat-light-green;
 				color: white;
 			}
+			.no-rec .card-header {
+				background-color: silver; // "No reduction" cards should be muted
+			}
 			.reduction {
 				text-align: center;
 				color: @gat-light-green;


### PR DESCRIPTION
As before - scoping and object-identity issues meant that caching of previously-generated recommendation lists wasn't working perfectly, and multiple generate-recommendations processes were getting fired off at once.
Depends on matching PR https://github.com/good-loop/wwappbase.js/pull/207 in wwappbase.