### PR TITLE
Bugfix/2023 08/creative recs misc

### DIFF
--- a/src/js/components/pages/greendash/GreenRecsCreative.tsx
+++ b/src/js/components/pages/greendash/GreenRecsCreative.tsx
@@ -327,7 +327,7 @@ function AnalyseTagPrompt({ tag, manifest }): JSX.Element {
 	if (manifest) {
 		return <h5 className="text-center pull-right">
 			{(!manifest.timestamp) ? <>Previously analysed.</> : (
-				<>Last analysed <Misc.RelativeDate date={new Date(manifest.timestamp)} />.</>
+				<>Last analysed <Misc.RelativeDate date={Math.min(new Date().getTime(), manifest.timestamp)} />.</>
 			)}<br/>
 			<Button className="my-2" onClick={doIt}>Re-Analyse</Button>
 		</h5>;

--- a/src/js/components/pages/greendash/GreenRecsCreative.tsx
+++ b/src/js/components/pages/greendash/GreenRecsCreative.tsx
@@ -125,7 +125,7 @@ function CreativeSizeBreakdown({ manifest }) {
 	const toggle = () => setOpen(a => !a);
 
 	return <>
-		{manifest || true ? <Button onClick={toggle}>Show Data Breakdown</Button> : 'Analyse to view data breakdown'}
+		{manifest ? <Button onClick={toggle}>Show Data Breakdown</Button> : 'Analyse to view data breakdown'}
 		<Modal isOpen={open} className="type-breakdown-modal" toggle={toggle}>
 			<ModalHeader toggle={toggle}>Breakdown of Creative Data</ModalHeader>
 			<ModalBody>


### PR DESCRIPTION
Creative Recommendations bugfixes. As commit messages - fixes issues where:
- "Creative data breakdown" button appears when it shouldn't (because there's no manifest to source the breakdown)
- Analyse button doesn't lock while doing fresh analysis (clicking the Analyse button has a higher-level component show the "loading" spinner, meaning several sub-components get unmounted, lose their state, and remount forgetting they should be "loading")
- User with a slow system clock will see a fresh analysis saying e.g. "Done 30 seconds in the future"