### PR TITLE
Impact overview navbars alt --> title

### DIFF
--- a/src/js/components/impact/ImpactNavBars.jsx
+++ b/src/js/components/impact/ImpactNavBars.jsx
@@ -1,21 +1,13 @@
-import React, { useState } from 'react';
-import { Collapse, Nav, Navbar, NavbarToggler, NavItem } from 'reactstrap';
-import { useTransition, animated, useSpring } from 'react-spring';
-import AccountMenu from '../../base/components/AccountMenu';
-import Icon from '../../base/components/Icon';
-import LinkOut from '../../base/components/LinkOut';
-import DevOnly from '../../base/components/DevOnly';
-import Logo from '../../base/components/Logo';
-import Campaign from '../../base/data/Campaign';
-import KStatus from '../../base/data/KStatus';
-import { getDataItem } from '../../base/plumbing/Crud';
-import Roles from '../../base/Roles';
+import React from 'react';
+import { Nav, Navbar, NavbarToggler, NavItem } from 'reactstrap';
+import { animated, useSpring } from 'react-spring';
 
-import { encURI, is, isMobile, space } from '../../base/utils/miscutils';
+import DevOnly from '../../base/components/DevOnly';
+import { space } from '../../base/utils/miscutils';
 import C from '../../C';
 import ServerIO from '../../plumbing/ServerIO';
-import { isPer1000 } from '../pages/greendash/GreenMetrics';
-import { ShareDash } from '../pages/greendash/GreenNavBar';
+
+
 const A = C.A;
 
 
@@ -25,13 +17,13 @@ const NavEntryCommon = ({name, pageKey, href, devOnly, urlFilters, doReload, opa
 
 	const item = top ? (
 		<NavItem className={activeClass}>
-			<A href={href} onClick={doReload} alt={name}>
+			<A href={href} onClick={doReload} title={name}>
 				<div className="impact-navbar-text">{name}</div>
 			</A>
 		</NavItem>
 	) : (
 		<NavItem>
-			<A href={href} onClick={doReload} alt={name}>
+			<A href={href} onClick={doReload} title={name}>
 				<div className={space('navbar-link', activeClass)}>
 					<div className={`impact-nav-icon ${pageKey}-icon`} />
 					<animated.div className="impact-navbar-text" style={{opacity}}>{name}</animated.div>


### PR DESCRIPTION
The nav icons have no labels & need hover text - they're supposed to have it, but were set up using attribute "alt", which is explicitly intended to provide a stand-in for images, for accessibility and graceful-failure purposes. This PR changes them to use the "title" attribute.