### PR TITLE
prop call changed to method call

### DIFF
--- a/src/js/components/campaignpage/CampaignPage.jsx
+++ b/src/js/components/campaignpage/CampaignPage.jsx
@@ -324,7 +324,7 @@ const CampaignPage = () => {
 					totalViewCount={totalViewCount} landing={isLanding} status={status} nvertiserName={nvertiserName}
 					ctaModalOpen={ctaModalOpen} setCtaModalOpen={setCtaModalOpen}
 					/>
-				<HowDoesItWork nvertiserName={nvertiserName} charities={charities} ongoing={campaign.ongoing} 
+				<HowDoesItWork nvertiserName={nvertiserName} charities={charities} ongoing={Campaign.isOngoing(campaign)} 
 					setCtaModalOpen={setCtaModalOpen} campaignId={campaign.id}
 					/>
 

--- a/src/js/components/campaignpage/HowDoesItWork.jsx
+++ b/src/js/components/campaignpage/HowDoesItWork.jsx
@@ -36,7 +36,7 @@ const HowDoesItWork = ({ nvertiserName, charities, ongoing, setCtaModalOpen, cam
 						<img src="/img/Graphic_leafy_video.scaled.400w.png" className="w-100" alt="choose charity" />
 						3. Once the donation {ongoing ? "is" : "was"} unlocked,
 						{charities.length > 1 ? (
-							" the user " + (ongoing ? "can" : "could") + " then choose which charity they " + (ongoing ? "want" : "wanted") + " to fund with 50% of the ad money."
+							" the user " + (ongoing ? "can" : "could") + " then choose which charity they " + (ongoing ? "want" : "wanted") + " to fund with 50% of the ad money. "
 						) : (
 							(campaignId === "zeni_aviv_8412" ? " 20%" : " 50%") + " of the ad money raised " + (ongoing ? "is" : "was") + " sent to " + (charityName || "charity") + "."
 						)}


### PR DESCRIPTION
client is frustrated with the "How it's done" text on their impact page. When digging into this, it turns out that detecting if a campaign is running or not hasn't been working for at least 7 months...

Now if a campaigns end date is in the future, the page will use present tense while it'll use past tense for prior campaigns. 